### PR TITLE
12bit cleanup

### DIFF
--- a/camera.c
+++ b/camera.c
@@ -487,11 +487,11 @@ int loadCamera() {
         unsigned int nMin = nRange[0];
         unsigned int nMax = nRange[1];
         unsigned int nInc = nRange[2];
-        printf("|\tPixelclock min, max, inc: %d, %d, %d \t\t |\n", nMin, nMax, nInc);
+        printf("|\tPixelclock min, max, inc: %d, %d, %d  \t\t |\n", nMin, nMax, nInc);
     }
 
     // how clear images can be is affected by pixelclock and fps 
-    pixelclock = 99;
+    pixelclock = 25;
     if (is_PixelClock(camera_handle, IS_PIXELCLOCK_CMD_SET, 
                       (void *) &pixelclock, sizeof(pixelclock)) != IS_SUCCESS) {
         cam_error = printCameraError();
@@ -1500,10 +1500,10 @@ int doCameraAndAstrometry() {
     }
 
     // make kst display the filtered image 
-    memcpy(output_buffer, unpacked_image, CAMERA_WIDTH*CAMERA_HEIGHT*sizeof(uint16_t)); 
+    memcpy(output_buffer, unpacked_image, CAMERA_WIDTH * CAMERA_HEIGHT * sizeof(uint16_t));
 
-    // pointer for transmitting to user should point to where image is in memory
-    camera_raw = output_buffer;
+    // pass off the image bytes for sending to clients
+    memcpy(camera_raw, output_buffer, CAMERA_WIDTH * CAMERA_HEIGHT * sizeof(uint16_t));
 
     // get current time right after exposure
     if (clock_gettime(CLOCK_REALTIME, &camera_tp_beginning) == -1) {
@@ -1536,7 +1536,7 @@ int doCameraAndAstrometry() {
 
         strftime(time_str, sizeof(time_str), "%Y-%m-%d_%H:%M:%S", tm_info);
         sprintf(date, "/home/starcam/Desktop/TIMSC/BMPs/auto_focus_at_%d_"
-                      "brightest_blob_%d_at_x%d_y%d_%s.bmp", 
+                      "brightest_blob_%d_at_x%d_y%d_%s.png", 
                 all_camera_params.focus_position, brightest_blob, 
                 brightest_blob_x, brightest_blob_y, time_str);
         if (verbose) {
@@ -1663,7 +1663,7 @@ int doCameraAndAstrometry() {
         }
 
         strftime(date, sizeof(date), "/home/starcam/Desktop/TIMSC/BMPs/"
-                                     "saved_image_%Y-%m-%d_%H:%M:%S.bmp", 
+                                     "saved_image_%Y-%m-%d_%H:%M:%S.png", 
                                      tm_info);
         swprintf(filename, 200, L"%s", date);
 
@@ -1725,9 +1725,9 @@ int doCameraAndAstrometry() {
 
     wprintf(L"Saving to \"%s\"\n", filename);
     // unlink whatever the latest saved image was linked to before
-    unlink("/home/starcam/Desktop/TIMSC/BMPs/latest_saved_image.bmp");
+    unlink("/home/starcam/Desktop/TIMSC/BMPs/latest_saved_image.png");
     // sym link current date to latest image for live Kst updates
-    symlink(date, "/home/starcam/Desktop/TIMSC/BMPs/latest_saved_image.bmp");
+    symlink(date, "/home/starcam/Desktop/TIMSC/BMPs/latest_saved_image.png");
 
     // make a table of blobs for Kst
     if (makeTable("makeTable.txt", star_mags, star_x, star_y, blob_count) != 1) {

--- a/camera.c
+++ b/camera.c
@@ -480,7 +480,18 @@ int loadCamera() {
         return -1;
     }
 
-    // Check pixelclock allowed values
+    // set frame rate
+    fps = 10;
+    if (is_SetFrameRate(camera_handle, IS_GET_FRAMERATE, (void *) &fps) 
+        != IS_SUCCESS) {
+        cam_error = printCameraError();
+        printf("Error setting frame rate: %s.\n", cam_error);
+        return -1;
+    }
+
+    pixelclock = 25;
+    // Check pixelclock allowed values, in case settings changes have caused it
+    // to differ
     unsigned int nRange[3] = {0};
     int nRet = is_PixelClock(camera_handle, IS_PIXELCLOCK_CMD_GET_RANGE, (void*)nRange, sizeof(nRange));
     if (nRet == IS_SUCCESS)
@@ -489,10 +500,11 @@ int loadCamera() {
         unsigned int nMax = nRange[1];
         unsigned int nInc = nRange[2];
         printf("|\tPixelclock min, max, inc: %d, %d, %d  \t\t |\n", nMin, nMax, nInc);
+        
+        pixelclock = nMin;
     }
 
     // how clear images can be is affected by pixelclock and fps 
-    pixelclock = 25;
     if (is_PixelClock(camera_handle, IS_PIXELCLOCK_CMD_SET, 
                       (void *) &pixelclock, sizeof(pixelclock)) != IS_SUCCESS) {
         cam_error = printCameraError();
@@ -504,15 +516,6 @@ int loadCamera() {
                   sizeof(curr_pc));
     if (verbose) {
         printf("|\tPixel clock: %i\t\t\t\t\t  |\n", curr_pc);
-    }
-
-    // set frame rate
-    fps = 10;
-    if (is_SetFrameRate(camera_handle, IS_GET_FRAMERATE, (void *) &fps) 
-        != IS_SUCCESS) {
-        cam_error = printCameraError();
-        printf("Error setting frame rate: %s.\n", cam_error);
-        return -1;
     }
 
     // set trigger to software mode (call is_FreezeVideo to take single picture 

--- a/camera.c
+++ b/camera.c
@@ -421,7 +421,8 @@ int loadCamera() {
 
     // initialize camera
     if (is_InitCamera(&camera_handle, NULL) != IS_SUCCESS) {
-        printf("Error initializing camera in loadCamera().\n");
+        cam_error = printCameraError();
+        printf("Error initializing camera in loadCamera(): %s.\n", cam_error);
         return -1;
     }
   
@@ -623,6 +624,7 @@ void makeMask(uint16_t * ib, int i0, int j0, int i1, int j1, int x0, int y0,
     
     int cutoff = all_blob_params.spike_limit*100.0;
 
+    // Zero out borders of mask array
     for (i = i0; i < i1; i++) {
         mask[i + CAMERA_WIDTH*j0] = mask[i + (j1-1)*CAMERA_WIDTH] = 0;
     }
@@ -853,7 +855,7 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
     // lowpass filter the image - reduce noise.
     boxcarFilterImage(input_buffer, i0, j0, i1, j1, all_blob_params.r_smooth, 
                       ic);
-        // test code to grab real filtered images if we want.
+    // test code to grab real filtered images if we want.
     /* for (int j = 0; j < CAMERA_HEIGHT; j++)
     {
         for (int i = 0; i < CAMERA_WIDTH; i++)
@@ -1718,7 +1720,7 @@ int doCameraAndAstrometry() {
     // save image for future reference
     ImageFileParams.pwchFileName = filename;
     if (is_ImageFile(camera_handle, IS_IMAGE_FILE_CMD_SAVE, 
-                    (void *) &ImageFileParams, sizeof(ImageFileParams)) == -1) {
+                    (void *) &ImageFileParams, sizeof(ImageFileParams)) != IS_SUCCESS) {
         const char * last_error_str = printCameraError();
         printf("Failed to save image: %s\n", last_error_str);
     }

--- a/camera.h
+++ b/camera.h
@@ -6,6 +6,7 @@
 #define CAMERA_WIDTH   1936 	 // [px]
 #define CAMERA_HEIGHT  1216	     // [px]
 #define CAMERA_MARGIN  0		 // [px]
+#define CAMERA_MAX_PIXVAL 4095 //  2**12
 // pixel scale search range bounds -> 6.0 to 6.5 for SO, 6.0 to 7.0 for BLAST
 #define MIN_PS         6.0       // [arcsec/px]
 #define MAX_PS         7.0		 // [arcsec/px]
@@ -62,7 +63,6 @@ int makeTable(char * filename, double * star_mags, double * star_x,
               double * star_y, int blob_count);
 int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x, 
               double ** star_y, double ** star_mags, uint16_t * output_buffer);
-// void unpack12Bit(uint8_t * packed, uint16_t * unpacked, int num_pixels);
 void unpack_mono12(uint16_t * packed, uint16_t * unpacked, int num_pixels);
 
-#endif 
+#endif

--- a/commands.c
+++ b/commands.c
@@ -83,8 +83,8 @@ int command_lock = 0;
 int cancelling_auto_focus = 0;
 // assume non-verbose output
 int verbose = 0;
-uint16_t* camera_raw[CAMERA_WIDTH * CAMERA_HEIGHT] = NULL;
-// if 0, then camera is not closing, so keep solving astrometry       
+uint16_t camera_raw[CAMERA_WIDTH * CAMERA_HEIGHT] = {0};
+// if 0, then camera is not closing, so keep solving astrometry
 int shutting_down = 0;
 // return values for terminating the threads
 int astro_thread_ret, client_thread_ret;

--- a/commands.c
+++ b/commands.c
@@ -245,7 +245,7 @@ void * processClient(void * for_client_thread) {
             // if another client sends commands at the same time, wait until 
             // they are done
             while (command_lock) {
-                usleep(100000);
+                usleep(1000);
             }
             // now it's this client's turn to execute commands (lock)
             command_lock = 1;

--- a/commands.c
+++ b/commands.c
@@ -83,7 +83,7 @@ int command_lock = 0;
 int cancelling_auto_focus = 0;
 // assume non-verbose output
 int verbose = 0;
-void * camera_raw = NULL;
+uint16_t* camera_raw[CAMERA_WIDTH * CAMERA_HEIGHT] = NULL;
 // if 0, then camera is not closing, so keep solving astrometry       
 int shutting_down = 0;
 // return values for terminating the threads
@@ -379,7 +379,7 @@ void * processClient(void * for_client_thread) {
         } 
 
 
-        if (send(socket, camera_raw, CAMERA_WIDTH*CAMERA_HEIGHT, 
+        if (send(socket, camera_raw, sizeof(camera_raw), 
                  MSG_NOSIGNAL) <= 0) {
             printf("Client dropped the connection.\n");
             break;

--- a/commands.h
+++ b/commands.h
@@ -1,12 +1,15 @@
-#include "astrometry.h"
 #ifndef COMMANDS_H
 #define COMMANDS_H
+
+#include "astrometry.h"
+#include "camera.h"
 
 extern int num_clients;
 extern int telemetry_sent;
 extern int cancelling_auto_focus;
 extern int verbose;
-extern uint16_t* camera_raw;
+extern uint16_t camera_raw[CAMERA_WIDTH * CAMERA_HEIGHT];
 void * processClient(void * arg);
 extern struct mcp_astrometry mcp_astro;
+
 #endif

--- a/commands.h
+++ b/commands.h
@@ -6,7 +6,7 @@ extern int num_clients;
 extern int telemetry_sent;
 extern int cancelling_auto_focus;
 extern int verbose;
-extern void * camera_raw;
+extern uint16_t* camera_raw;
 void * processClient(void * arg);
 extern struct mcp_astrometry mcp_astro;
 #endif


### PR DESCRIPTION
Tying up loose ends of 12bit conversion.

See comments at the end of #3.

### Testing

I have taken images indoors and checked to make sure that they're writing to disk, I can open them, and there's data inside. I've also verified that the GUI is unbroken (or will be once the PR to display 12bit images goes through).

![saved_image_2025-05-28_02:27:10](https://github.com/user-attachments/assets/7b557ff0-669e-49a3-beb6-2003a9ee2bce)

My image programs open this as a 16-bit png with grey values mapped between 0-65535, i.e. the max brightness value is not 2^12-1 but 2^16-1. It seems to be done by iDS upon saving, not by the programs that read the file.

TBD: on-sky testing.