### PR TITLE
Major API change: Support iDS Peak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Build directory
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project ("commands"
 
 # If you install ids peak via the tar archive, you'll need to point to it here
 set(CMAKE_PREFIX_PATH "/home/starcam/ids-peak-with-ueyetl_2.16.0.0-457_amd64/lib/")
+set(CMAKE_C_FLAGS_DEBUG "-O0 -fno-omit-frame-pointer -ggdb -g3")
 
 # Create target executable
 add_executable (${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.2...3.12 FATAL_ERROR)
+
+project ("commands"
+    LANGUAGES
+        C
+)
+
+# If you install ids peak via the tar archive, you'll need to point to it here
+set(CMAKE_PREFIX_PATH "/home/starcam/ids-peak-with-ueyetl_2.16.0.0-457_amd64/lib/")
+
+# Create target executable
+add_executable (${PROJECT_NAME}
+    commands.c commands.h
+    camera.c camera.h
+    lens_adapter.c lens_adapter.h
+    astrometry.c astrometry.h
+    matrix.c matrix.h
+    sc_send.c sc_send.h
+    sc_listen.c sc_listen.h
+    sc_data_structures.h
+)
+
+# Command compiler to use C99 standard (required by ids_peak_comfort_c)
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        C_STANDARD 99
+        C_STANDARD_REQUIRED ON
+)
+
+find_package(ids_peak_comfort_c REQUIRED)
+find_package(ids_peak REQUIRED)
+find_package(ids_peak_afl REQUIRED)
+find_library(PEAK_IFL_PATH ids_peak_ifl ${CMAKE_PREFIX_PATH}) # not a cmake package but a bare .so
+find_package(ids_peak_ipl REQUIRED)
+
+# Setup include directories
+target_include_directories (${PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        /usr/local/astrometry/include
+        /usr/local/sofa/include
+)
+
+# import required, prebuilt local libraries
+# if you installed astrometry.net or SOFA in different places, you'll need to
+# update them here
+add_library( astrometry SHARED IMPORTED )
+set_target_properties( astrometry PROPERTIES IMPORTED_LOCATION /usr/local/astrometry/lib/libastrometry.so )
+add_library( sofa SHARED IMPORTED )
+set_target_properties( sofa PROPERTIES IMPORTED_LOCATION /usr/local/sofa/lib/libsofa_c.a )
+
+# Link libraries
+target_link_libraries (${PROJECT_NAME}
+    pthread
+    sofa
+    astrometry
+    # ueye_api
+    ids_peak_comfort_c::ids_peak_comfort_c
+    ids_peak
+    ids_peak_afl
+    ${PEAK_IFL_PATH}
+    ids_peak_ipl
+    m
+)
+
+# required to conditionally compile starcam code until we remove dependency on
+# ueye old api
+add_compile_definitions(IDS_PEAK)
+
+# help find our shared libraries at runtime, after make install
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Add postbuild step to copy ids_peak_comfort_c dependencies
+ids_peak_comfort_c_deploy(${PROJECT_NAME})
+
+# For unix Build we need the environment variable GENICAM_GENTL32_PATH respectively GENICAM_GENTL64_PATH to find the GenTL producer libraries.
+# To set these environment variables a shell script is used. This script can be automatically generated via ids_peak_comfort_c_generate_starter_script.
+# The shell script will be saved at ${CMAKE_CURRENT_BINARY_DIR}/${targetName}.sh and automatically copied to the output directory during post-build.
+
+# To run the samples run this script, not the binary.
+if(UNIX)
+    ids_peak_comfort_c_generate_starter_script(${PROJECT_NAME})
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: release
 
 release: commands.c commands.h camera.c camera.h lens_adapter.c lens_adapter.h astrometry.c astrometry.h matrix.c matrix.h sc_send.c sc_send.h sc_listen.c sc_listen.h sc_data_structures.h
-	gcc commands.c camera.c lens_adapter.c matrix.c astrometry.c sc_listen.c sc_send.c -lsofa -lpthread -lastrometry -lueye_api -lm -o commands
+	gcc commands.c camera.c lens_adapter.c matrix.c astrometry.c sc_listen.c sc_send.c -I/usr/local/include/sofa/ -lsofa -lpthread -lastrometry -lueye_api -lm -o commands
 
 debug: commands.c commands.h camera.c camera.h lens_adapter.c lens_adapter.h astrometry.c astrometry.h matrix.c matrix.h sc_send.c sc_send.h sc_listen.c sc_listen.h sc_data_structures.h
-	gcc -g -Og commands.c camera.c lens_adapter.c matrix.c astrometry.c sc_listen.c sc_send.c -lsofa -lpthread -lastrometry -lueye_api -lm -o commands
+	gcc -g -Og commands.c camera.c lens_adapter.c matrix.c astrometry.c sc_listen.c sc_send.c -I/usr/local/include/sofa/ -lsofa -lpthread -lastrometry -lueye_api -lm -o commands
 
 .PHONY: clean
 

--- a/astrometry.c
+++ b/astrometry.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <math.h>
+#include <errno.h>
 #include <astrometry/os-features.h>
 #include <astrometry/engine.h>
 #include <astrometry/solver.h>
@@ -11,9 +12,7 @@
 #include <astrometry/log.h>
 #include <astrometry/errors.h>
 #include <astrometry/fileutils.h>
-#include <ueye.h>
-#include <sofa/sofa.h>
-#include <errno.h>
+#include <sofa.h>
 
 #include "camera.h"
 #include "astrometry.h"
@@ -36,20 +35,20 @@ struct mcp_astrometry mcp_astro;
 
 /* Astrometry parameters global structure, accessible from commands.c as well */
 struct astrometry all_astro_params = {
-	.timelimit = 1,
-	.rawtime = 0,
-	.logodds = 1e8,
-	.latitude = backyard_lat,
-	.longitude = backyard_long,
-	.hm = backyard_hm,
-	.ra = 0, 
-	.dec = 0,
-	.fr = 0,
-	.ps = 0,
-	.ir = 0,
-	.alt = 0,
-	.az = 0,
-	.sigma_pointing_as = 0,
+    .timelimit = 1,
+    .rawtime = 0,
+    .logodds = 1e8,
+    .latitude = backyard_lat,
+    .longitude = backyard_long,
+    .hm = backyard_hm,
+    .ra = 0, 
+    .dec = 0,
+    .fr = 0,
+    .ps = 0,
+    .ir = 0,
+    .alt = 0,
+    .az = 0,
+    .sigma_pointing_as = 0,
 };
 
 /* Function to decrement a counter for tracking Astrometry timeout.
@@ -57,31 +56,31 @@ struct astrometry all_astro_params = {
 ** Output: If the counter has reached zero yet (or not).
 */
 time_t timeout(void * arg) {
-	int * counter = (int *) arg;
+    int * counter = (int *) arg;
 
-	if (*(counter) != 0) {
-		if (verbose) {
-			printf("Have yet to solve Astrometry. Decrementing time "
-			       "counter...\n");
-		}
+    if (*(counter) != 0) {
+        if (verbose) {
+            printf("Have yet to solve Astrometry. Decrementing time "
+                   "counter...\n");
+        }
 
-		(*counter)--;
+        (*counter)--;
 
-		if (verbose) {
-			printf("Timeout counter is now %d.\n", *counter);
-		}
-	} 
+        if (verbose) {
+            printf("Timeout counter is now %d.\n", *counter);
+        }
+    } 
 
-	// if we are shutting down, we don't want to keep trying to solve (we just
-	// want to abort altogether)
-	if (shutting_down) {
-		if (verbose) {
-			printf("Shutting down -> zeroing timeout counter.\n");
-		}
-		*counter = 0;
-	}
+    // if we are shutting down, we don't want to keep trying to solve (we just
+    // want to abort altogether)
+    if (shutting_down) {
+        if (verbose) {
+            printf("Shutting down -> zeroing timeout counter.\n");
+        }
+        *counter = 0;
+    }
 
-	return (*counter != 0);
+    return (*counter != 0);
 }
 
 
@@ -90,21 +89,25 @@ time_t timeout(void * arg) {
 ** Output: Flag indicating successful initialization of Astrometry system
 */
 int initAstrometry() {
-	engine = engine_new();
-	solver = solver_new();
-	
-	if (engine_parse_config_file(engine, 
-	                             "/usr/local/astrometry/etc/astrometry.cfg")) {
-		printf("Bad configuration file in Astrometry constructor.\n");
-		return -1;
-	}
+    engine = engine_new();
+    solver = solver_new();
 
-	// set solver timeout
-	solver_timelimit = (int) all_astro_params.timelimit;
-	solver->timer_callback = timeout;
-	solver->userdata = &solver_timelimit;
+    if (verbose) {
+        printf("initAstrometry: initializing...\n");
+    }
+    
+    if (engine_parse_config_file(engine, 
+                                 "/usr/local/astrometry/etc/astrometry.cfg")) {
+        printf("Bad configuration file in Astrometry constructor.\n");
+        return -1;
+    }
 
-	return 1;
+    // set solver timeout
+    solver_timelimit = (int) all_astro_params.timelimit;
+    solver->timer_callback = timeout;
+    solver->userdata = &solver_timelimit;
+
+    return 1;
 }
 
 /* Function to close astrometry.
@@ -112,11 +115,11 @@ int initAstrometry() {
 ** Output: None (void).
 */
 void closeAstrometry() {	
-	if (verbose) {
-		printf("Closing Astrometry...\n");
-	}
-	engine_free(engine);
-	solver_free(solver);
+    if (verbose) {
+        printf("Closing Astrometry...\n");
+    }
+    engine_free(engine);
+    solver_free(solver);
 }
 
 /* Function for solving for pointing location on the sky.
@@ -126,246 +129,246 @@ void closeAstrometry() {
 ** Output: the status of finding a solution or not (sol_status).
 */
 int lostInSpace(double * star_x, double * star_y, double * star_mags, unsigned 
-				num_blobs, struct tm * tm_info, char * datafile) {
-	int sol_status;
-	// timers for astrometry
-	struct timespec astrom_tp_beginning, astrom_tp_end; 
-	double hprange, start, end, astrom_time;
-	double ra, dec, fr, ps, ir, sigma_pointing;
-	// for apportioning Julian dates
-	double d1, d2;
-	// 'ob' means observed (observed frame versus ICRS frame)
-	double aob, zob, hob, dob, rob, eo;
-	FILE * fptr = NULL;
+                num_blobs, struct tm * tm_info, char * datafile) {
+    int sol_status;
+    // timers for astrometry
+    struct timespec astrom_tp_beginning, astrom_tp_end; 
+    double hprange, start, end, astrom_time;
+    double ra, dec, fr, ps, ir, sigma_pointing;
+    // for apportioning Julian dates
+    double d1, d2;
+    // 'ob' means observed (observed frame versus ICRS frame)
+    double aob, zob, hob, dob, rob, eo;
+    FILE * fptr = NULL;
 
-	// reset solver timeout
-	solver_timelimit = (int) all_astro_params.timelimit;
-	if (verbose) {
-		printf("Astrom. timeout is %i cycles.\n", *((int *) solver->userdata));
-	}
-
-	// set up solver configuration
-	solver->funits_lower = MIN_PS;
-	solver->funits_upper = MAX_PS;
-	
-	// set max number of sources
-	solver->endobj = num_blobs;
-
-	// disallow tiny quads
-	solver->quadsize_min = 0.1*MIN(CAMERA_WIDTH - 2*CAMERA_MARGIN, 
-	                               CAMERA_HEIGHT - 2*CAMERA_MARGIN);
-
-	// set parity which can speed up x2
-	solver->parity = PARITY_BOTH; 
-	
-	// sets the odds ratio we will accept (logodds parameter)
-	solver_set_keep_logodds(solver, log(all_astro_params.logodds));  
-
-	solver->logratio_totune = log(1e6);
-	solver->logratio_toprint = log(1e6);
-	solver->distance_from_quad_bonus = 1;
-
-	// figure out the index file range to search in
-	hprange = arcsec2dist(MAX_PS*hypot(CAMERA_WIDTH - 2*CAMERA_MARGIN, 
-	                                   CAMERA_HEIGHT - 2*CAMERA_MARGIN)/2.0);
-
-	// make list of stars
-	starxy_t * field = starxy_new(num_blobs, 1, 0);
-
-	// start timer for astrometry 
-	if (clock_gettime(CLOCK_REALTIME, &astrom_tp_beginning) == -1) {
-		fprintf(stderr, "Unable to start timer: %s.\n", strerror(errno));
+    // reset solver timeout
+    solver_timelimit = (int) all_astro_params.timelimit;
+    if (verbose) {
+        printf("Astrom. timeout is %i cycles.\n", *((int *) solver->userdata));
     }
 
-	starxy_set_x_array(field, star_x);
-	starxy_set_y_array(field, star_y);
-	starxy_set_flux_array(field, star_mags);
-	starxy_sort_by_flux(field);
+    // set up solver configuration
+    solver->funits_lower = MIN_PS;
+    solver->funits_upper = MAX_PS;
+    
+    // set max number of sources
+    solver->endobj = num_blobs;
 
-	solver_set_field(solver, field);
-	solver_set_field_bounds(solver, 0, CAMERA_WIDTH - 2*CAMERA_MARGIN, 0, 
-	                        CAMERA_HEIGHT - 2*CAMERA_MARGIN);
+    // disallow tiny quads
+    solver->quadsize_min = 0.1*MIN(CAMERA_WIDTH - 2*CAMERA_MARGIN, 
+                                   CAMERA_HEIGHT - 2*CAMERA_MARGIN);
 
-	// add index files
-	for (int i = 0; i < (int) pl_size((*engine).indexes); i++) {
-		index_t * index = (index_t *) pl_get((*engine).indexes, i);
-		solver_add_index(solver, index);
-		index_reload(index);
-	}
+    // set parity which can speed up x2
+    solver->parity = PARITY_BOTH; 
+    
+    // sets the odds ratio we will accept (logodds parameter)
+    solver_set_keep_logodds(solver, log(all_astro_params.logodds));  
 
-	solver_log_params(solver);
-	solver_run(solver);
+    solver->logratio_totune = log(1e6);
+    solver->logratio_toprint = log(1e6);
+    solver->distance_from_quad_bonus = 1;
 
-	// solution status should be 0 since we have yet to achieve a solution 
-	sol_status = 0;
-	if ((fptr = fopen(datafile, "a")) == NULL) {
-		fprintf(stderr, "Could not open observing file: %s.\n", 
-				strerror(errno));
-		return sol_status;
-	}
-	if ((*solver).best_match_solves) {
-		double pscale;
-		tan_t * wcs;
+    // figure out the index file range to search in
+    hprange = arcsec2dist(MAX_PS*hypot(CAMERA_WIDTH - 2*CAMERA_MARGIN, 
+                                       CAMERA_HEIGHT - 2*CAMERA_MARGIN)/2.0);
 
-		// get World Coordinate System data (wcs)
-		wcs = &((*solver).best_match.wcstan);
-		tan_pixelxy2radec(wcs, (CAMERA_WIDTH - 2*CAMERA_MARGIN - 1)/2.0, 
-		                       (CAMERA_HEIGHT - 2*CAMERA_MARGIN - 1)/2.0, &ra, 
-							   &dec);
-		
-		// calculate pixel scale and field rotation
-		ps = tan_pixel_scale(wcs);
-		fr = tan_get_orientation(wcs); 
+    // make list of stars
+    starxy_t * field = starxy_new(num_blobs, 1, 0);
 
-		// calculate Julian date
-		if (iauDtf2d("UTC", tm_info->tm_year + 1900, tm_info->tm_mon + 1, 
-		                    tm_info->tm_mday, tm_info->tm_hour, tm_info->tm_min,
-							(double) tm_info->tm_sec, &d1, &d2) != 0) {
-			printf("Julian date not properly calculated.\n");
-			return sol_status;
-		}
+    // start timer for astrometry 
+    if (clock_gettime(CLOCK_REALTIME, &astrom_tp_beginning) == -1) {
+        fprintf(stderr, "Unable to start timer: %s.\n", strerror(errno));
+    }
 
-		// calculate AltAz
-		if (iauAtco13(ra*(M_PI/180.0), dec*(M_PI/180.0), 0.0, 0.0, 0.0, 0.0, d1,
-		              d2 + (all_camera_params.exposure_time/(2000.0*3600.0*24.0)), 
-					  dut1, all_astro_params.longitude*(M_PI/180.0), 
-					  all_astro_params.latitude*(M_PI/180.0), 
-					  all_astro_params.hm, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-				      &aob, &zob, &hob, &dob, &rob, &eo) != 0) {
-			printf("Review preceding Julian date calculation; dubious year or "
-			       "unacceptable date passed to AltAz calculation.\n");
-			return sol_status;
-		}
+    starxy_set_x_array(field, star_x);
+    starxy_set_y_array(field, star_y);
+    starxy_set_flux_array(field, star_mags);
+    starxy_sort_by_flux(field);
 
-		// calculate parallactic angle and add it to field rotation to get image
-		// rotation
-		ir = (iauHd2pa(hob, dob, 
-		               all_astro_params.latitude*(M_PI/180.0)))*(180.0/M_PI) - fr;
+    solver_set_field(solver, field);
+    solver_set_field_bounds(solver, 0, CAMERA_WIDTH - 2*CAMERA_MARGIN, 0, 
+                            CAMERA_HEIGHT - 2*CAMERA_MARGIN);
 
-		// Calculate the RMS uncertainty for the particular starfield that was
-		// just matched
-		// Get the ra, dec positions of the best-matching database field of
-		// stars from their unit sphere xyz coords
-		MatchObj* mo = &((*solver).best_match);
-		mo->refradec = malloc(3 * mo->nindex * sizeof(double));
-		for (uint i = 0; i < mo->nindex; i++)
-		{
-			xyzarr2radecdegarr(mo->refxyz + i * 3, mo->refradec + i * 2);
-		}
-		// generate the sip from the wsctan
-		sip_t sip;
-		sip_wrap_tan(wcs, &sip);
+    // add index files
+    for (int i = 0; i < (int) pl_size((*engine).indexes); i++) {
+        index_t * index = (index_t *) pl_get((*engine).indexes, i);
+        solver_add_index(solver, index);
+        index_reload(index);
+    }
 
-		double sum_sq_diffs = 0;
-		int counter = 0;
-		for (uint j = 0; j < solver->best_match.nfield; j++)
-		{
-			// Unpack the reference star locations from the best match object and translate them to XY coordinates
-			double fx, fy, rx, ry, refRA, refDec;
-			int ti, ri;
-			ri = mo->theta[j];
-			if (ri < 0)
-			{
-				continue;
-			}
-			ti = j;
-			refRA = mo->refradec[2*ri+0];
-			refDec = mo->refradec[2*ri+1];
-			if (!sip_radec2pixelxy(&sip, refRA, refDec, &rx, &ry))
-			{
-				continue;
-			}
-			// Get the pixel positions of the blobs we found
-			fx = solver->fieldxy->x[ti];
-			fy = solver->fieldxy->y[ti];
-			
-			// rolling total of the sum of the square differences
-			sum_sq_diffs += ((fx - rx) * (fx - rx)) + ((fy - ry) * (fy - ry));
-			counter++;
-		}
+    solver_log_params(solver);
+    solver_run(solver);
 
-		// Convert sum of square differences into RMS uncertainty 
-		sigma_pointing = sqrt(sum_sq_diffs / counter);
-		double sigma_pointing_as = sigma_pointing * ps;
+    // solution status should be 0 since we have yet to achieve a solution 
+    sol_status = 0;
+    if ((fptr = fopen(datafile, "a")) == NULL) {
+        fprintf(stderr, "Could not open observing file: %s.\n", 
+                strerror(errno));
+        return sol_status;
+    }
+    if ((*solver).best_match_solves) {
+        double pscale;
+        tan_t * wcs;
 
-		// end timer
-		if (clock_gettime(CLOCK_REALTIME, &astrom_tp_end) == -1) {
-        	fprintf(stderr, "Error ending timer: %s.\n", strerror(errno));
-    	}
-		mcp_astro.dec_j2000 = dec;
-		mcp_astro.ra_j2000 = ra;
-		mcp_astro.dec_observed = dob*(180.0/M_PI);
-		mcp_astro.ra_observed = rob*(180.0/M_PI);
-		mcp_astro.image_rms = sigma_pointing_as;
-		// update astro struct with telemetry
-		all_astro_params.dec_j2000 = dec;
-		all_astro_params.ra_j2000 = ra;
-		all_astro_params.ir = ir;
-		all_astro_params.ra = rob*(180.0/M_PI);
-		all_astro_params.dec = dob*(180.0/M_PI);
-		all_astro_params.alt = 90.0 - (zob*(180.0/M_PI));
-		all_astro_params.az = aob*(180.0/M_PI); 
-		all_astro_params.fr = fr;
-		all_astro_params.ps = ps;
-		all_astro_params.sigma_pointing_as = sigma_pointing_as;
+        // get World Coordinate System data (wcs)
+        wcs = &((*solver).best_match.wcstan);
+        tan_pixelxy2radec(wcs, (CAMERA_WIDTH - 2*CAMERA_MARGIN - 1)/2.0, 
+                               (CAMERA_HEIGHT - 2*CAMERA_MARGIN - 1)/2.0, &ra, 
+                               &dec);
+        
+        // calculate pixel scale and field rotation
+        ps = tan_pixel_scale(wcs);
+        fr = tan_get_orientation(wcs); 
 
-		printf("\n+---------------------------------------------------------+\n");
-		printf("|\t\tTelemetry\t\t\t\t  |\n");
-		printf("|---------------------------------------------------------|\n");
-		printf("|\tRaw time (sec): %.1f\t\t\t  |\n", all_astro_params.rawtime);
-		printf("|\tNumber of blobs found: %i\t\t\t  |\n", num_blobs);
-		printf("|\tAstrometry RA (deg): %lf\t\t\t  |\n", ra);
-		printf("|\tAstrometry DEC (deg): %lf\t\t\t  |\n", dec);
-		printf("|\tObserved RA (deg): %lf\t\t\t  |\n", all_astro_params.ra);
-		printf("|\tObserved DEC (deg): %lf\t\t\t  |\n", all_astro_params.dec);
-		printf("|\tField rotation (deg): %f\t\t  |\n", all_astro_params.fr);
-		printf("|\tImage rotation (deg): %lf\t\t  |\n", all_astro_params.ir);
-		printf("|\tPixel scale (arcsec/px): %lf\t\t  |\n", all_astro_params.ps);
-		printf("|\tAltitude (deg): %.15f\t\t  |\n", all_astro_params.alt);
-		printf("|\tAzimuth (deg): %.15f\t\t  |\n", all_astro_params.az);
-		printf("|\tPointing uncertainty (arcsec): %.3lf\t\t  |\n", all_astro_params.sigma_pointing_as);
-		printf("+---------------------------------------------------------+\n\n");
+        // calculate Julian date
+        if (iauDtf2d("UTC", tm_info->tm_year + 1900, tm_info->tm_mon + 1, 
+                            tm_info->tm_mday, tm_info->tm_hour, tm_info->tm_min,
+                            (double) tm_info->tm_sec, &d1, &d2) != 0) {
+            printf("Julian date not properly calculated.\n");
+            return sol_status;
+        }
+
+        // calculate AltAz
+        if (iauAtco13(ra*(M_PI/180.0), dec*(M_PI/180.0), 0.0, 0.0, 0.0, 0.0, d1,
+                      d2 + (all_camera_params.exposure_time/(2000.0*3600.0*24.0)), 
+                      dut1, all_astro_params.longitude*(M_PI/180.0), 
+                      all_astro_params.latitude*(M_PI/180.0), 
+                      all_astro_params.hm, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                      &aob, &zob, &hob, &dob, &rob, &eo) != 0) {
+            printf("Review preceding Julian date calculation; dubious year or "
+                   "unacceptable date passed to AltAz calculation.\n");
+            return sol_status;
+        }
+
+        // calculate parallactic angle and add it to field rotation to get image
+        // rotation
+        ir = (iauHd2pa(hob, dob, 
+                       all_astro_params.latitude*(M_PI/180.0)))*(180.0/M_PI) - fr;
+
+        // Calculate the RMS uncertainty for the particular starfield that was
+        // just matched
+        // Get the ra, dec positions of the best-matching database field of
+        // stars from their unit sphere xyz coords
+        MatchObj* mo = &((*solver).best_match);
+        mo->refradec = malloc(3 * mo->nindex * sizeof(double));
+        for (uint i = 0; i < mo->nindex; i++)
+        {
+            xyzarr2radecdegarr(mo->refxyz + i * 3, mo->refradec + i * 2);
+        }
+        // generate the sip from the wsctan
+        sip_t sip;
+        sip_wrap_tan(wcs, &sip);
+
+        double sum_sq_diffs = 0;
+        int counter = 0;
+        for (uint j = 0; j < solver->best_match.nfield; j++)
+        {
+            // Unpack the reference star locations from the best match object and translate them to XY coordinates
+            double fx, fy, rx, ry, refRA, refDec;
+            int ti, ri;
+            ri = mo->theta[j];
+            if (ri < 0)
+            {
+                continue;
+            }
+            ti = j;
+            refRA = mo->refradec[2*ri+0];
+            refDec = mo->refradec[2*ri+1];
+            if (!sip_radec2pixelxy(&sip, refRA, refDec, &rx, &ry))
+            {
+                continue;
+            }
+            // Get the pixel positions of the blobs we found
+            fx = solver->fieldxy->x[ti];
+            fy = solver->fieldxy->y[ti];
+            
+            // rolling total of the sum of the square differences
+            sum_sq_diffs += ((fx - rx) * (fx - rx)) + ((fy - ry) * (fy - ry));
+            counter++;
+        }
+
+        // Convert sum of square differences into RMS uncertainty 
+        sigma_pointing = sqrt(sum_sq_diffs / counter);
+        double sigma_pointing_as = sigma_pointing * ps;
+
+        // end timer
+        if (clock_gettime(CLOCK_REALTIME, &astrom_tp_end) == -1) {
+            fprintf(stderr, "Error ending timer: %s.\n", strerror(errno));
+        }
+        mcp_astro.dec_j2000 = dec;
+        mcp_astro.ra_j2000 = ra;
+        mcp_astro.dec_observed = dob*(180.0/M_PI);
+        mcp_astro.ra_observed = rob*(180.0/M_PI);
+        mcp_astro.image_rms = sigma_pointing_as;
+        // update astro struct with telemetry
+        all_astro_params.dec_j2000 = dec;
+        all_astro_params.ra_j2000 = ra;
+        all_astro_params.ir = ir;
+        all_astro_params.ra = rob*(180.0/M_PI);
+        all_astro_params.dec = dob*(180.0/M_PI);
+        all_astro_params.alt = 90.0 - (zob*(180.0/M_PI));
+        all_astro_params.az = aob*(180.0/M_PI); 
+        all_astro_params.fr = fr;
+        all_astro_params.ps = ps;
+        all_astro_params.sigma_pointing_as = sigma_pointing_as;
+
+        printf("\n+---------------------------------------------------------+\n");
+        printf("|\t\tTelemetry\t\t\t\t  |\n");
+        printf("|---------------------------------------------------------|\n");
+        printf("|\tRaw time (sec): %.1f\t\t\t  |\n", all_astro_params.rawtime);
+        printf("|\tNumber of blobs found: %i\t\t\t  |\n", num_blobs);
+        printf("|\tAstrometry RA (deg): %lf\t\t\t  |\n", ra);
+        printf("|\tAstrometry DEC (deg): %lf\t\t\t  |\n", dec);
+        printf("|\tObserved RA (deg): %lf\t\t\t  |\n", all_astro_params.ra);
+        printf("|\tObserved DEC (deg): %lf\t\t\t  |\n", all_astro_params.dec);
+        printf("|\tField rotation (deg): %f\t\t  |\n", all_astro_params.fr);
+        printf("|\tImage rotation (deg): %lf\t\t  |\n", all_astro_params.ir);
+        printf("|\tPixel scale (arcsec/px): %lf\t\t  |\n", all_astro_params.ps);
+        printf("|\tAltitude (deg): %.15f\t\t  |\n", all_astro_params.alt);
+        printf("|\tAzimuth (deg): %.15f\t\t  |\n", all_astro_params.az);
+        printf("|\tPointing uncertainty (arcsec): %.3lf\t\t  |\n", all_astro_params.sigma_pointing_as);
+        printf("+---------------------------------------------------------+\n\n");
 
 
-		// calculate how long solution took to solve in terms of nanoseconds
-		start = (double) (astrom_tp_beginning.tv_sec*1e9) + (double) astrom_tp_beginning.tv_nsec;
-		end = (double) (astrom_tp_end.tv_sec*1e9) + (double) astrom_tp_end.tv_nsec;
-    		astrom_time = end - start;
-		printf("Astrometry solved in %f msec.\n", astrom_time*1e-6);
+        // calculate how long solution took to solve in terms of nanoseconds
+        start = (double) (astrom_tp_beginning.tv_sec*1e9) + (double) astrom_tp_beginning.tv_nsec;
+        end = (double) (astrom_tp_end.tv_sec*1e9) + (double) astrom_tp_end.tv_nsec;
+            astrom_time = end - start;
+        printf("Astrometry solved in %f msec.\n", astrom_time*1e-6);
 
-		// write astrometry solution to data.txt file
-		if (verbose) {
-			printf(" > Writing Astrometry solution to data file...\n");
-		}
+        // write astrometry solution to data.txt file
+        if (verbose) {
+            printf(" > Writing Astrometry solution to data file...\n");
+        }
 
-		if (fprintf(fptr, "%i,%lf,%lf,%lf,%lf,%lf,%lf,%.15f,%.15f,%lf,%f,%.15lf", num_blobs,
-						ra, dec,
-              			all_astro_params.ra, all_astro_params.dec, 
-  						all_astro_params.fr, all_astro_params.ps, 
-  						all_astro_params.alt, all_astro_params.az, 
-  						all_astro_params.ir, astrom_time*1e-6,
-						all_astro_params.sigma_pointing_as) < 0) {
-  			fprintf(stderr, "Error writing solution to observing file: %s.\n", 
-  	        	strerror(errno));
-  		}
-	
-		fflush(fptr);
-		fclose(fptr);
+        if (fprintf(fptr, "%i,%lf,%lf,%lf,%lf,%lf,%lf,%.15f,%.15f,%lf,%f,%.15lf", num_blobs,
+                        ra, dec,
+                          all_astro_params.ra, all_astro_params.dec, 
+                          all_astro_params.fr, all_astro_params.ps, 
+                          all_astro_params.alt, all_astro_params.az, 
+                          all_astro_params.ir, astrom_time*1e-6,
+                        all_astro_params.sigma_pointing_as) < 0) {
+              fprintf(stderr, "Error writing solution to observing file: %s.\n", 
+                  strerror(errno));
+          }
+    
+        fflush(fptr);
+        fclose(fptr);
 
-		// we achieved a solution!
-		sol_status = 1;
-	} else {
-		// if no solution was found, write a line of 0s to the data file for ease of post-run data analysis
-		if (fprintf(fptr, "0,0,0,0,0,0,0,0,0,0,0,0") < 0) {
+        // we achieved a solution!
+        sol_status = 1;
+    } else {
+        // if no solution was found, write a line of 0s to the data file for ease of post-run data analysis
+        if (fprintf(fptr, "0,0,0,0,0,0,0,0,0,0,0,0") < 0) {
             fprintf(stderr, "Unable to write time and blob count to observing file: %s.\n", strerror(errno));
-			}
-		fflush(fptr);
-		fclose(fptr);
+            }
+        fflush(fptr);
+        fclose(fptr);
     }
-	
-	// clean everything up and return the status
-	solver_cleanup_field(solver);
-	solver_clear_indexes(solver);
+    
+    // clean everything up and return the status
+    solver_cleanup_field(solver);
+    solver_clear_indexes(solver);
 
-	return sol_status;
+    return sol_status;
 }

--- a/astrometry.h
+++ b/astrometry.h
@@ -37,4 +37,4 @@ extern struct mcp_astrometry mcp_astro;
 
 extern struct astrometry all_astro_params;
 
-#endif 
+#endif

--- a/camera.c
+++ b/camera.c
@@ -510,11 +510,7 @@ int initCamera(void) {
     // // set how images are saved
     // setSaveImage();
 
-    // In iDS peak, we can call peak_Frame_Save() on a frame handle
-    // to save an image with default compression/quality settings. For a .png,
-    // this is compression ratio 25.
-    // This suffices for now, because eventually we will save and compress FITS
-    // files and this will be deprecated.
+    // Image saving handled in imageTransfer()
 
     if (verbose) {
         printf("initCamera: starting image acquisition...\n");
@@ -1627,12 +1623,6 @@ int imageTransfer(uint16_t* pUnpackedImage, char* filename) {
     // TODO(evanmayer): if we want more image data, like the timestamp in camera
     // time (since camera init), we could query here.
 
-    // NOTE(evanmayer): for now, save to disk in here. Later, the unpacked buffer
-    // will be written to disk as FITS.
-    if (saveImageToDisk(filename, hFrame) < 0) {
-        fprintf(stderr, "WARNING: Failed to save frame to disk.\n");
-    }
-
     // For the Mono12 unpacked format, each pixel occupies two bytes, and we can
     // iterate after casting the memory pointer
     if (verbose) {
@@ -1644,6 +1634,12 @@ int imageTransfer(uint16_t* pUnpackedImage, char* filename) {
     // frame buffer memory
     unpack_mono12((uint16_t *)buffer.memoryAddress, pUnpackedImage,
         CAMERA_WIDTH * CAMERA_HEIGHT);
+
+    // NOTE(evanmayer): for now, save to disk in here. Later, the unpacked buffer
+    // will be written to disk as FITS.
+    if (saveImageToDisk(filename, hFrame) < 0) {
+        fprintf(stderr, "WARNING: Failed to save frame to disk.\n");
+    }
 
     status = peak_Frame_Release(hCam, hFrame);
     if(!checkForSuccess(status)) {

--- a/camera.c
+++ b/camera.c
@@ -17,6 +17,12 @@
 #include "matrix.h"
 #include "sc_data_structures.h"
 
+#define MIN_BLOBS 4
+#define MAX_BLOBS 9999
+
+void merge(double A[], int p, int q, int r, double X[],double Y[]);
+void part(double A[], int p, int r, double X[], double Y[]);
+
 #ifdef IDS_PEAK
 #include <ids_peak_comfort_c/ids_peak_comfort_c.h>
 peak_camera_handle hCam = PEAK_INVALID_HANDLE;
@@ -81,12 +87,6 @@ IMAGE_FILE_PARAMS ImageFileParams;
 // same with sensorInfo struct
 SENSORINFO sensorInfo;
 #endif
-
-#define MIN_BLOBS 4
-#define MAX_BLOBS 9999
-
-void merge(double A[], int p, int q, int r, double X[],double Y[]);
-void part(double A[], int p, int r, double X[], double Y[]);
 
 // global variables
 int image_solved[2] = {0};

--- a/camera.c
+++ b/camera.c
@@ -414,7 +414,7 @@ int setMinTriggerDivider(void) {
 
 
 /**
- * @brief Get the exposure time in milliseconds.
+ * @brief Get the analog gain factor.
  * 
  * @param[out] pAnalogGain pointer to output actual analog gain factor
  * @return int -1 if failed, 0 otherwise
@@ -668,7 +668,7 @@ int getFps(double* pCurrentFps)
 
 /**
  * @brief Set the framerate, although it doesn't apply in software trigger mode,
- * only in freerun mode
+ * only in freerun mode. Side effect: updates metadata struct
  * 
  * @param frameRateFps
  * @return int -1 if failed, 0 otherwise
@@ -728,6 +728,12 @@ int getPixelClock(double* pCurrentPixelClockMHz)
 }
 
 
+/**
+ * @brief Sets the Pixel Clock to the minimum available value.
+ * @details For the U3-31N0CP-M-GL, the only option is 216 MHz.
+ * 
+ * @return int -1 if failed, 0 otherwise
+ */
 int setMinPixelClock(void)
 {
     int ret = 0;
@@ -879,8 +885,9 @@ int getExposureTime(double* pExposureTimeMs)
 
 
 /**
- * @brief Set the exposure time in milliseconds. Side effect: updates metadata
- * struct
+ * @brief Set the exposure time in milliseconds. If the request value is not
+ * available, the closest available value is chosen. Side effect: updates
+ * metadata struct.
  * 
  * @param exposureTimeMs requested exposure time (ms)
  * @return int -1 if failed, 0 otherwise
@@ -3248,8 +3255,8 @@ int doCameraAndAstrometry(void)
         return -1;
     }
     #else
-    char dummyFileName[] = "/home/starcam/Desktop/TIMSC/BMPs/image.png";
-    if (imageTransfer(unpacked_image, dummyFileName) < 0) {
+    char tmpFileName[] = "/home/starcam/Desktop/TIMSC/BMPs/image.png";
+    if (imageTransfer(unpacked_image, tmpFileName) < 0) {
         fprintf(stderr, "Could not complete image transfer: %s.\n", 
            strerror(errno));
         return -1;
@@ -3559,7 +3566,7 @@ int doCameraAndAstrometry(void)
     // The frame was saved to disk at transfer time, when the frame handle was
     // available, with a generic name. Now that we have the final filename,
     // rename the generic saved file on disk.
-    if (rename(dummyFileName, filename)) {
+    if (rename(tmpFileName, filename)) {
         fprintf(stderr, "Unable to rename captured image file to %s: %s.\n",
             filename, strerror(errno));
     }

--- a/camera.c
+++ b/camera.c
@@ -2076,12 +2076,14 @@ int getNumberOfCameras(int* pNumCams) {
 int saveImageToDisk(char* filename)
 {
     int ret = 0;
-    ImageFileParams.pwchFileName = (wchar_t*)filename;
+    wchar_t wFilename[200];
+    swprintf(wFilename, 200, L"%s", filename);
+    ImageFileParams.pwchFileName = wFilename;
     if (is_ImageFile(camera_handle, IS_IMAGE_FILE_CMD_SAVE, 
                     (void *) &ImageFileParams,
                     sizeof(ImageFileParams)) != IS_SUCCESS) {
         const char * last_error_str = printCameraError();
-        printf("Failed to save image: %s\n", last_error_str);
+        printf("Failed to save image to file %ls: %s\n", wFilename, last_error_str);
         ret = -1;
     }
     return ret;

--- a/camera.c
+++ b/camera.c
@@ -298,8 +298,8 @@ int getTriggerDelay(double* pCurrentTriggerDelayUs)
             }
         }
     } else {
-        fprintf(stderr, "getTriggerDelay: Failed to get actual trigger delay \
-                value, trigger delay not readable at this time.\n");
+        fprintf(stderr, "getTriggerDelay: Failed to get actual trigger delay "
+                "value, trigger delay not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -324,20 +324,20 @@ int setMinTriggerDelay(void)
         double doubleInc = 0.0;
         peak_status status = peak_Trigger_Delay_GetRange(hCam, &doubleMin, &doubleMax, &doubleInc);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "setTriggerDelay: Checking trigger delay range \
-                failed. Attempting to set to 0 in absence of min val.\n");
+            fprintf(stderr, "setTriggerDelay: Checking trigger delay range "
+                "failed. Attempting to set to 0 in absence of min val.\n");
             ret = -1;
         }
 
         status = peak_Trigger_Delay_Set(hCam, doubleMin);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "setTriggerDelay: Setting trigger delay to min \
-                failed.\n");
+            fprintf(stderr, "setTriggerDelay: Setting trigger delay to min "
+                "failed.\n");
             ret = -1;
         }
     } else {
-        fprintf(stderr, "setTriggerDelay: Failed to set state of trigger delay,\
-                         not writeable at this time.\n");
+        fprintf(stderr, "setTriggerDelay: Failed to set state of trigger delay,"
+                        " not writeable at this time.\n");
         ret = -1;
     }
 
@@ -365,8 +365,8 @@ int getTriggerDivider(uint32_t* pCurrentTriggerDivider)
         uint32_t actualTriggerDivider = 1;
         peak_status status = peak_Trigger_Divider_Get(hCam, pCurrentTriggerDivider);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "getTriggerDivider: Checking trigger divider value \
-                 failed.\n");
+            fprintf(stderr, "getTriggerDivider: Checking trigger divider value "
+                 "failed.\n");
                 ret = -1;
         } else {
             if (verbose) {
@@ -375,8 +375,8 @@ int getTriggerDivider(uint32_t* pCurrentTriggerDivider)
             }
         }
     } else {
-        fprintf(stderr, "getTriggerDivider: Failed to get actual trigger \
-            divider value, trigger divider not readable at this time.\n");
+        fprintf(stderr, "getTriggerDivider: Failed to get actual trigger "
+            "divider value, trigger divider not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -397,13 +397,13 @@ int setMinTriggerDivider(void) {
         // Eschew range checks. 1 will always be a valid divisor.
         peak_status status = peak_Trigger_Divider_Set(hCam, 1);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "setTriggerDivider: Setting trigger divider failed.\
-                \n");
+            fprintf(stderr, "setTriggerDivider: Setting trigger divider failed."
+                "\n");
             ret = -1;
         }
     } else {
-        fprintf(stderr, "setTriggerDivider: Failed to set state of trigger \
-            divider, not writeable at this time.\n");
+        fprintf(stderr, "setTriggerDivider: Failed to set state of trigger "
+            "divider, not writeable at this time.\n");
         ret =-1;
     }
 
@@ -438,8 +438,8 @@ int getMonoAnalogGain(double* pAnalogGain)
             }
         }
     } else {
-        fprintf(stderr, "getMonoAnalogGain: Failed to get actual gain, gain not\
-             readable at this time.\n");
+        fprintf(stderr, "getMonoAnalogGain: Failed to get actual gain, gain not"
+            " readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -483,8 +483,8 @@ int setMonoAnalogGain(double analogGain)
             ret = -1;
         }
     } else {
-        fprintf(stderr, "Failed to set requested gain value %f. Gain is not\
-            writable at this time.\n", analogGain);
+        fprintf(stderr, "Failed to set requested gain value %f. Gain is not "
+            "writeable at this time.\n", analogGain);
         ret = -1;
     }
 
@@ -511,8 +511,8 @@ int getAutoExposureEnabled(int *pIsEnabled)
         peak_auto_feature_mode mode = PEAK_AUTO_FEATURE_MODE_INVALID;
         peak_status status = peak_AutoBrightness_Exposure_Mode_Get(hCam, &mode);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "getAutoExposureEnabled: Checking autoexposure \
-                    mode failed.\n");
+            fprintf(stderr, "getAutoExposureEnabled: Checking autoexposure "
+                    "mode failed.\n");
                     ret = -1;
         } else {
             if (PEAK_AUTO_FEATURE_MODE_OFF == mode) {
@@ -523,8 +523,8 @@ int getAutoExposureEnabled(int *pIsEnabled)
             }
         }
     } else {
-        fprintf(stderr, "getAutoExposureEnabled: Failed to get autoexposure \
-            state, not readable at this time.\n");
+        fprintf(stderr, "getAutoExposureEnabled: Failed to get autoexposure "
+            "state, not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -544,13 +544,13 @@ int disableAutoExposure(void)
         peak_status status = peak_AutoBrightness_Exposure_Mode_Set(hCam,
             PEAK_AUTO_FEATURE_MODE_OFF);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "disableAutoExposure: Setting autoexposure off \
-                failed.\n");
+            fprintf(stderr, "disableAutoExposure: Setting autoexposure off "
+                "failed.\n");
             ret = -1;
         }
     } else {
-        fprintf(stderr, "disableAutoExposure: Failed to set autoexposure, not \
-            writeable at this time.\n");
+        fprintf(stderr, "disableAutoExposure: Failed to set autoexposure, not "
+            "writeable at this time.\n");
         ret = -1;
     }
 
@@ -577,8 +577,8 @@ int getAutoGainEnabled(int* pIsEnabled)
         peak_auto_feature_mode mode = PEAK_AUTO_FEATURE_MODE_INVALID;
         peak_status status = peak_AutoBrightness_Gain_Mode_Get(hCam, &mode);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "getAutoGainEnabled: Checking autogain mode \
-                failed.\n");
+            fprintf(stderr, "getAutoGainEnabled: Checking autogain mode "
+                "failed.\n");
             ret = -1;
         } else {
             if (PEAK_AUTO_FEATURE_MODE_OFF == mode) {
@@ -589,8 +589,8 @@ int getAutoGainEnabled(int* pIsEnabled)
             }
         }
     } else {
-        fprintf(stderr, "getAutoGainEnabled: Failed to get autogain state, \
-            not readable at this time.\n");
+        fprintf(stderr, "getAutoGainEnabled: Failed to get autogain state, "
+            "not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -610,13 +610,13 @@ int disableAutoGain(void)
         peak_status status = peak_AutoBrightness_Gain_Mode_Set(hCam,
             PEAK_AUTO_FEATURE_MODE_OFF);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "disableAutoGain: Setting autogain off failed. \
-                Continuing.\n");
+            fprintf(stderr, "disableAutoGain: Setting autogain off failed. "
+                "Continuing.\n");
             ret = -1;
         }
     } else {
-        fprintf(stderr, "disableAutoGain: Failed to set autogain, not \
-            writeable at this time.\n");
+        fprintf(stderr, "disableAutoGain: Failed to set autogain, not "
+            "writeable at this time.\n");
         ret = -1;
     }
 
@@ -660,8 +660,8 @@ int getFps(double* pCurrentFps)
             }
         }
     } else {
-        fprintf(stderr, "getFps: Failed to get actual framerate value, \
-            framerate not readable at this time.\n");
+        fprintf(stderr, "getFps: Failed to get actual framerate value, "
+            "framerate not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -687,8 +687,8 @@ int setFps(double frameRateFps)
             ret = -1;
         }
     } else {
-        fprintf(stderr, "setFps: Failed to set framerate value, framerate not \
-            writeable at this time.\n");
+        fprintf(stderr, "setFps: Failed to set framerate value, framerate not "
+            "writeable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -722,8 +722,8 @@ int getPixelClock(double* pCurrentPixelClockMHz)
             }
         }
     } else {
-        fprintf(stderr, "getPixelClock: Failed to get actual pixelclock value,\
-                pixel clock not readable at this time.\n");
+        fprintf(stderr, "getPixelClock: Failed to get actual pixelclock value,"
+            " pixel clock not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -754,6 +754,10 @@ int setMinPixelClock(void)
                 // and maxPixelClockMHz with an increment of incPixelClockMHz.
                 pixelClockValueMHz = minPixelClockMHz;
             }
+            if (verbose) {
+                printf("setMinPixelClock: got range %f - %f, step %f MHz.\n",
+                    minPixelClockMHz, maxPixelClockMHz, incPixelClockMHz);
+            }
         } else {
             // The valid values are organized as a list.
             size_t pixelClockCount = 0;
@@ -768,12 +772,17 @@ int setMinPixelClock(void)
                     // A valid value for the pixel clock is one of pixelClockList.
                     pixelClockValueMHz = pixelClockList[0];
                 }
+                if (verbose) {
+                    printf("setMinPixelClock: got list:\n");
+                    for (int i = 0; i < pixelClockCount; i++) {
+                        printf("\t- %f\n", pixelClockList[i]);
+                    }
+                }
             }
         }
     }  else {
-        fprintf(stderr, "setMinPixelClock: Failed to set pixelclock to minimum,\
-                pixel clock not readable at this time.\n");
-        ret = -1;
+        fprintf(stderr, "WARNING: setMinPixelClock: Failed to get pixelclock "
+            "minimum value, pixel clock not readable at this time.\n");
     }
 
     accessStatus = peak_PixelClock_GetAccessStatus(hCam);
@@ -787,10 +796,16 @@ int setMinPixelClock(void)
             // despite not knowing the limits
             ret = 0;
         }
-    }  else {
-        fprintf(stderr, "setMinPixelClock: Failed to set pixelclock to minimum,\
-                pixel clock not writable at this time.\n");
-        ret = -1;
+    } else {
+        // Some cameras may not have user-settable pixel clocks. Don't fail if 
+        // setting fails due to readonly.
+        if (PEAK_ACCESS_READONLY == accessStatus) {
+            ret = 0;
+        } else {
+            fprintf(stderr, "setMinPixelClock: Failed to set pixelclock "
+                "to minimum, pixel clock not writeable at this time.\n");
+            ret = -1;
+        }
     }
 
     // Update metadata
@@ -845,19 +860,19 @@ int getExposureTime(double* pExposureTimeMs)
     if (PEAK_IS_READABLE(accessStatus)) {
         peak_status status = peak_ExposureTime_Get(hCam, &actualExposureTimeUs);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "getExposureTime: Failed to get actual exposure \
-                time.\n");
+            fprintf(stderr, "getExposureTime: Failed to get actual exposure "
+                "time.\n");
             ret = -1;
         } else {
             if (verbose) {
-                printf("getExposureTime: Actual exposure time is %f (us)\n",
+                printf("getExposureTime: Actual exposure time is %f us\n",
                     actualExposureTimeUs);
             }
             *pExposureTimeMs = actualExposureTimeUs * 1000.0;
         }
     } else {
-        fprintf(stderr, "getExposureTime: Failed to get actual exposure \
-            time, exposure time not readable at this time.\n");
+        fprintf(stderr, "getExposureTime: Failed to get actual exposure "
+            "time, exposure time not readable at this time.\n");
         ret = -1;
     }
 
@@ -889,23 +904,23 @@ int setExposureTime(double exposureTimeMs)
             &maxExposureTimeUs, &incExposureTimeUs);
 
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "setExposureTime: Failed to check exposure time \
-                range. Continuing.\n");
+            fprintf(stderr, "setExposureTime: Failed to check exposure time "
+                "range. Continuing.\n");
         } else {
             if (verbose) {
-                printf("setExposureTime: Available exposure time range is \
-                    %f - %f, step %f (us).\n",
-                    minExposureTimeUs, maxExposureTimeUs, incExposureTimeUs);
+                printf("setExposureTime: Available exposure time range is "
+                    "%f - %f, step %f us.\n", minExposureTimeUs,
+                    maxExposureTimeUs, incExposureTimeUs);
             }
         }
 
         if (exposureTimeUs < minExposureTimeUs) {
             exposureTimeUs = minExposureTimeUs;
-            printf("setExposureTime: Requested exposure too short. Corrected to %f (us).\n",
+            printf("setExposureTime: Requested exposure too short. Corrected to %f us.\n",
                 exposureTimeUs);
         } else if (exposureTimeUs > maxExposureTimeUs) {
             exposureTimeUs = maxExposureTimeUs;
-            printf("setExposureTime: Requested exposure too long. Corrected to %f (us).\n",
+            printf("setExposureTime: Requested exposure too long. Corrected to %f us.\n",
                 exposureTimeUs);
         }
     }
@@ -916,14 +931,13 @@ int setExposureTime(double exposureTimeMs)
     if (PEAK_IS_WRITEABLE(accessStatus)) {
         status = peak_ExposureTime_Set(hCam, exposureTimeUs);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "setExposureTime: Failed to set requested exposure \
-                time %f (us).\n",
-                exposureTimeUs);
+            fprintf(stderr, "setExposureTime: Failed to set requested exposure "
+                "time %f us.\n", exposureTimeUs);
             ret = -1;
         }
     } else {
-        fprintf(stderr, "setExposureTime: Exposure time is not writable at \
-            this time.\n");
+        fprintf(stderr, "setExposureTime: Exposure time is not writeable at "
+            "this time.\n");
         ret = -1;
     }
 
@@ -955,8 +969,8 @@ int getAutoBlackLevelEnabled(int* pIsEnabled)
             *pIsEnabled = 0;
         }
     } else {
-        fprintf(stderr, "getAutoBlackLevelEnabled: Failed to get state of auto \
-            black level offset, not readable at this time.\n");
+        fprintf(stderr, "getAutoBlackLevelEnabled: Failed to get state of auto "
+            "black level offset, not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -976,13 +990,13 @@ int disableAutoBlackLevel(void)
     if (PEAK_IS_WRITEABLE(accessStatus)) {
         peak_status status = peak_BlackLevel_Auto_Enable(hCam, PEAK_FALSE);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "disableAutoBlackLevel: Setting auto black level \
-                off failed.\n");
+            fprintf(stderr, "disableAutoBlackLevel: Setting auto black level "
+                "off failed.\n");
             ret = -1;
         }
     } else {
-        fprintf(stderr, "disableAutoBlackLevel: Failed to disable auto black \
-            level offset, not writable at this time.\n");
+        fprintf(stderr, "disableAutoBlackLevel: Failed to disable auto black "
+            "level offset, not writeable at this time.\n");
         ret = -1;
     }
 
@@ -1008,7 +1022,8 @@ int getBlackLevelOffset(double* pCurrentBlackLevelOffset)
     if (PEAK_IS_READABLE(accessStatus)) {
         peak_status status = peak_BlackLevel_Offset_Get(hCam, pCurrentBlackLevelOffset);
         if(!checkForSuccess(status)) {
-            fprintf(stderr, "getBlackLevelOffset: Failed to get black level offset.\n");
+            fprintf(stderr, "getBlackLevelOffset: Failed to get black level "
+                "offset.\n");
             ret = -1;
         } else {
             if (verbose) {
@@ -1017,8 +1032,8 @@ int getBlackLevelOffset(double* pCurrentBlackLevelOffset)
             }
         }
     } else {
-        fprintf(stderr, "getBlackLevelOffset: Failed to get actual black level \
-            offset value, value not readable at this time.\n");
+        fprintf(stderr, "getBlackLevelOffset: Failed to get actual black level "
+            "offset value, value not readable at this time.\n");
         ret = -1;
     }
     return ret;
@@ -1041,13 +1056,13 @@ int setBlackLevelOffset(double blackLevelOffset)
     if (PEAK_IS_WRITEABLE(accessStatus)) {
         peak_status status = peak_BlackLevel_Offset_Set(hCam, blackLevelOffset);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "setBlackLevelOffset: Setting black level offset \
-                value failed.\n");
+            fprintf(stderr, "setBlackLevelOffset: Setting black level offset "
+                "value failed.\n");
             ret = -1;
         }
     } else {
-        fprintf(stderr, "setBlackLevelOffset: Failed to set black level offset \
-            value, value not writeable at this time.\n");
+        fprintf(stderr, "setBlackLevelOffset: Failed to set black level offset "
+            "value, value not writeable at this time.\n");
         ret = -1;
     }
 
@@ -1209,8 +1224,8 @@ int initCamera(void)
     peak_status status = peak_CameraSettings_DiskFile_Store(hCam,
         initialParameterFile);
     if (!checkForSuccess(status)) {
-        fprintf(stderr, "ERROR: Failed to dump camera settings to disk %s on \
-            startup.\n", initialParameterFile);
+        fprintf(stderr, "ERROR: Failed to dump camera settings to disk %s on "
+            "startup.\n", initialParameterFile);
     }
 
     if (verbose) {
@@ -1278,8 +1293,8 @@ void closeCamera(void)
     if (PEAK_TRUE == peak_Acquisition_IsStarted(hCam)) {
         peak_status status = peak_Acquisition_Stop(hCam);
         if (!checkForSuccess(status)) {
-            fprintf(stderr, "ERROR: Failed to stop image acquisition. Exiting \
-                anyway\n");
+            fprintf(stderr, "ERROR: Failed to stop image acquisition. Exiting "
+                "anyway.\n");
         }
     }
 
@@ -1291,8 +1306,8 @@ void closeCamera(void)
     peak_status status = peak_CameraSettings_DiskFile_Store(hCam,
         finalParameterFile);
     if (!checkForSuccess(status)) {
-        fprintf(stderr, "ERROR: Failed to dump camera settings to disk %s on \
-            startup.\n", finalParameterFile);
+        fprintf(stderr, "ERROR: Failed to dump camera settings to disk %s on "
+            "shutdown.\n", finalParameterFile);
     }
 
 
@@ -2044,8 +2059,8 @@ int getNumberOfCameras(int* pNumCams) {
     size_t cameraListLength = 0;
     peak_status status = peak_CameraList_Get(NULL, &cameraListLength);
     if (!checkForSuccess(status)) {
-        fprintf(stderr, "ERROR: Getting the camera list length failed! Status: \
-            %#06x\n", status);
+        fprintf(stderr, "getNumberOfCameras: Getting the camera list length "
+            "failed.\n");
         (void)peak_Library_Exit();
         return -1;
     }
@@ -2269,8 +2284,8 @@ int imageTransfer(uint16_t* pUnpackedImage, char* filename)
     }
 
     // wait for image transfer
-    peak_status status = peak_Acquisition_WaitForFrame(hCam, three_frame_times_timeout_ms,
-        &hFrame);
+    peak_status status = peak_Acquisition_WaitForFrame(hCam,
+        three_frame_times_timeout_ms, &hFrame);
     if(status == PEAK_STATUS_TIMEOUT) {
         fprintf(stderr, "ERROR: WaitForFrame timed out after 3 frame times.\n");
         return -1;
@@ -2307,8 +2322,8 @@ int imageTransfer(uint16_t* pUnpackedImage, char* filename)
     // For the Mono12 unpacked format, each pixel occupies two bytes, and we can
     // iterate after casting the memory pointer
     if (verbose) {
-        printf("imageTransfer: Unpacking image bytes: %ld into local buffer of \
-            size %ld\n", buffer.memorySize,
+        printf("imageTransfer: Unpacking image bytes: %ld into local buffer of "
+            "size %ld\n", buffer.memorySize,
             (sizeof(uint16_t) * CAMERA_WIDTH * CAMERA_HEIGHT));
     }
 

--- a/camera.c
+++ b/camera.c
@@ -830,15 +830,15 @@ int setExposureTime(double exposureTimeMs)
 {
     int ret = 0;
     // run uEye function to update camera exposure
-    // After the call, the actual set exposure time is stored in newExposureTime
+    // After the call, the actual set exposure time is stored in exposureTimeMs
     if (is_Exposure(camera_handle, IS_EXPOSURE_CMD_SET_EXPOSURE, 
-                    (void *) &newExposureTime, 
+                    (void *) &exposureTimeMs, 
                     sizeof(double)) != IS_SUCCESS) {
         printf("Adjusting exposure to user command unsuccessful.\n");
         ret = -1;
     }
     if (verbose) {
-        printf("Exposure is now %f msec.\n", newExposureTime);
+        printf("Exposure is now %f msec.\n", exposureTimeMs);
     }
     return ret;
 }
@@ -2076,7 +2076,7 @@ int getNumberOfCameras(int* pNumCams) {
 int saveImageToDisk(char* filename)
 {
     int ret = 0;
-    ImageFileParams.pwchFileName = filename;
+    ImageFileParams.pwchFileName = (wchar_t*)filename;
     if (is_ImageFile(camera_handle, IS_IMAGE_FILE_CMD_SAVE, 
                     (void *) &ImageFileParams,
                     sizeof(ImageFileParams)) != IS_SUCCESS) {

--- a/camera.c
+++ b/camera.c
@@ -20,6 +20,57 @@
 #ifdef IDS_PEAK
 #include <ids_peak_comfort_c/ids_peak_comfort_c.h>
 peak_camera_handle hCam = PEAK_INVALID_HANDLE;
+
+// We include a default metadata struct here to help with initialization
+// elsewhere. This could also be handled in a template FITS with using the
+// FITSIO interface to template files.
+struct fits_metadata_t default_metadata = {
+
+    // Capture data
+
+    .origin = "blastcam",
+    .instrume = "TIMcam",
+    .telescop = "Sigma 85mm f/1.4 DG HSM ART",
+    .observat = "TIM",
+    .observer = "starcam",
+    .filename = "",
+    .date = "1970-00-00T00:00:00",
+    .utcsec = 0,
+    .utcusec = 0,
+    .filter = "B+W 091 (630nm)",
+    .ccdtemp = 0.0,
+    .focus = 0,
+    .aperture = 14,
+    .exptime = 0.1,
+    .bunit = "ADU",
+
+    // Compression settings
+
+    .fzalgor = "RICE_1",
+    .fztile = "ROW",
+
+    // Sensor settings
+
+    .detector = "iDS U3-31N0CP-M-GL Rev. 2.2",
+    .sensorid = 0,
+    .bitdepth = 12,
+    .pixscal1 = 6.63,
+    .pixscal2 = 6.63,
+    .pixsize1 = 2.74,
+    .pixsize2 = 2.74,
+    .darkcur = 1.38,
+    .rdnoise1 = 2.37,
+    .ccdbin1 = 1,
+    .ccdbin2 = 1,
+    .pixelclk = 99,
+    .framerte = 1.0,
+    .gainfact = 1.0,
+    .trigdlay = 0.0,
+    .bloffset = 0.0,
+    .autogain = 0,
+    .autoexp = 0,
+    .autoblk = 0
+};
 #else
 #include <ueye.h>
 // 1-254 are possible IDs. Command-line argument from user with ./commands
@@ -82,59 +133,6 @@ struct trigger_params all_trigger_params = {
     .trigger = 0, // not starting off triggered
     .trigger_mode = 0, // default to 
 };
-
-#ifdef IDS_PEAK
-// We include a default metadata struct here to help with initialization
-// elsewhere. This could also be handled in a template FITS with using the
-// FITSIO interface to template files.
-struct fits_metadata_t default_metadata = {
-
-    // Capture data
-
-    .origin = "blastcam",
-    .instrume = "TIMcam",
-    .telescop = "Sigma 85mm f/1.4 DG HSM ART",
-    .observat = "TIM",
-    .observer = "starcam",
-    .filename = "",
-    .date = "1970-00-00T00:00:00",
-    .utcsec = 0,
-    .utcusec = 0,
-    .filter = "B+W 091 (630nm)",
-    .ccdtemp = 0.0,
-    .focus = 0,
-    .aperture = 14,
-    .exptime = 0.1,
-    .bunit = "ADU",
-
-    // Compression settings
-
-    .fzalgor = "RICE_1",
-    .fztile = "ROW",
-
-    // Sensor settings
-
-    .detector = "iDS U3-31N0CP-M-GL Rev. 2.2",
-    .sensorid = 0,
-    .bitdepth = 12,
-    .pixscal1 = 6.63,
-    .pixscal2 = 6.63,
-    .pixsize1 = 2.74,
-    .pixsize2 = 2.74,
-    .darkcur = 1.38,
-    .rdnoise1 = 2.37,
-    .ccdbin1 = 1,
-    .ccdbin2 = 1,
-    .pixelclk = 99,
-    .framerte = 1.0,
-    .gainfact = 1.0,
-    .trigdlay = 0.0,
-    .bloffset = 0.0,
-    .autogain = 0,
-    .autoexp = 0,
-    .autoblk = 0
-};
-#endif
 
 
 /* Helper function to determine if a year is a leap year (2020 is a leap year).

--- a/camera.h
+++ b/camera.h
@@ -79,13 +79,13 @@ struct fits_metadata_t {
     char observat[10]; // OBSERVAT: observatory name
     char observer[10]; // OBSERVER: observer name
     char filename[200]; // FILENAME: basename + ext on disk
-    char date[200]; // DATE: time of file creation (UTC)
-    char utc_obs[200]; // UTC-OBS: time of observation start (UTC)
-    float julian; // JULIAN: Julian date of obs start
-    char filter[20]; // FILTER: fileter name
+    char date[200]; // DATE: time of file creation (UTC) to nearest second
+    uint64_t utcsec; // UTC-OBS-SEC: time of observation start, whole seconds portion since UNIX epoch
+    uint64_t utcusec; // UTC-OBS-USEC: time of observation start, microseconds portion since UNIX epoch
+    char filter[20]; // FILTER: filter name
     float ccdtemp; // CCDTEMP: camera temp (C)
     int16_t focus; // FOCUS: focus position (encoder units)
-    int8_t aperture; // APERTURE: aperture position (10x fstop)
+    int16_t aperture; // APERTURE: aperture position (10x fstop)
     float exptime; // EXPTIME: total exposure time (s)
     char bunit[4]; // BUNIT: physical unit of array values (ADU)
 
@@ -98,6 +98,7 @@ struct fits_metadata_t {
     // Sensor settings
 
     char detector[64]; // DETECTOR: sensor name
+    uint64_t sensorid; // SENSORID: camera unique numerical identifier
     uint8_t bitdepth; // BITDEPTH: requested bit depth of camera, not equivalent to BITPIX
     float pixscal1; // PIXSCAL1: plate scale, axis 1 (arcsec/px)
     float pixscal2; // PIXSCAL2: plate scale, axis 2 (arcsec/px)
@@ -114,8 +115,7 @@ struct fits_metadata_t {
     float trigdlay; // TRIGDLAY: trigger delay (ms)
     uint16_t bloffset; // BLOFFSET: black level offset setting, arb units
     int16_t autogain; // AUTOGAIN: automatic gain control on (1) off (0)
-    int16_t autoshut; // AUTOSHUT: automatic shutter control on (1) off (0)
-    int16_t autofrte; // AUTOFRTE: automatic framerate control on (1) off (0)
+    int16_t autoexp; // AUTOEXP: automatic exposure control on (1) off (0)
     int16_t autoblk; // AUTOBLK: automatic black level offset on (1) off (0)
 
     // TODO(evanmayer): add more WCS info fields?
@@ -143,14 +143,17 @@ int loadCamera();
 int initCamera();
 int getNumberOfCameras(int* pNumCams);
 int setExposureTime(double exposureTimeMs);
-double getFps(void);
+
 int imageCapture(void);
 #ifndef IDS_PEAK
+double getFps(void);
 int imageTransfer(uint16_t* pUnpackedImage);
 int saveImageToDisk(char* filename);
 #else
+int getFps(double* pCurrentFps);
 int imageTransfer(uint16_t* pUnpackedImage, char* filename);
 int saveImageToDisk(char* filename, peak_frame_handle hFrame);
+int recordMetadata(void);
 #endif
 int doCameraAndAstrometry();
 void clean();

--- a/camera.h
+++ b/camera.h
@@ -14,18 +14,20 @@ extern HIDS camera_handle;
 #ifndef IDS_PEAK
 #define CAMERA_WIDTH   1936 // [px]
 #define CAMERA_HEIGHT  1216 // [px]
+// pixel scale search range bounds -> 6.0 to 6.5 for SO, 6.0 to 7.0 for BLAST
 #define MIN_PS         6.0  // [arcsec/px]
 #define MAX_PS         7.0  // [arcsec/px]
 #else
 // TIMSC is IMX542
-#define CAMERA_WIDTH   5328 // [px]
-#define CAMERA_HEIGHT  3040 // [px]
+// Datasheet says array is 5328 x 3040, but this includes overscan. The active
+// area is 8px smaller each side.
+#define CAMERA_WIDTH   5320 // [px]
+#define CAMERA_HEIGHT  3032 // [px]
 #define MIN_PS         14.0  // [arcsec/px]
 #define MAX_PS         15.0  // [arcsec/px]
 #endif
 #define CAMERA_MARGIN  0		 // [px]
 #define CAMERA_MAX_PIXVAL 4095 //  2**12
-// pixel scale search range bounds -> 6.0 to 6.5 for SO, 6.0 to 7.0 for BLAST
 #define STATIC_HP_MASK "/home/starcam/Desktop/TIMSC/static_hp_mask.txt"
 #define dut1           -0.23
 

--- a/camera.h
+++ b/camera.h
@@ -2,18 +2,33 @@
 #define CAMERA_H
 #include "astrometry.h"
 
+#ifdef IDS_PEAK
+#include <ids_peak_comfort_c/ids_peak_comfort_c.h>
+extern peak_camera_handle hCam;
+#else
+#include <ueye.h>
+extern HIDS camera_handle;
+#endif
+
 // SO Star Camera is 1936 width by 1216 height; BLAST is 1392 by 1040
-#define CAMERA_WIDTH   1936 	 // [px]
-#define CAMERA_HEIGHT  1216	     // [px]
+#ifndef IDS_PEAK
+#define CAMERA_WIDTH   1936 // [px]
+#define CAMERA_HEIGHT  1216 // [px]
+#define MIN_PS         6.0  // [arcsec/px]
+#define MAX_PS         7.0  // [arcsec/px]
+#else
+// TIMSC is IMX542
+#define CAMERA_WIDTH   5328 // [px]
+#define CAMERA_HEIGHT  3040 // [px]
+#define MIN_PS         14.0  // [arcsec/px]
+#define MAX_PS         15.0  // [arcsec/px]
+#endif
 #define CAMERA_MARGIN  0		 // [px]
 #define CAMERA_MAX_PIXVAL 4095 //  2**12
 // pixel scale search range bounds -> 6.0 to 6.5 for SO, 6.0 to 7.0 for BLAST
-#define MIN_PS         6.0       // [arcsec/px]
-#define MAX_PS         7.0		 // [arcsec/px]
 #define STATIC_HP_MASK "/home/starcam/Desktop/TIMSC/static_hp_mask.txt"
 #define dut1           -0.23
 
-extern HIDS camera_handle;
 extern int shutting_down;
 extern int send_data;
 extern int taking_image;
@@ -54,11 +69,16 @@ void setSaveImage();
 int loadCamera();
 int initCamera();
 int getNumberOfCameras(int* pNumCams);
-int updateExposure(double newExposureTime);
+int setExposureTime(double exposureTimeMs);
 double getFps(void);
 int imageCapture(void);
+#ifndef IDS_PEAK
 int imageTransfer(uint16_t* pUnpackedImage);
-int saveImageToDisk(wchar_t* filename);
+int saveImageToDisk(char* filename);
+#else
+int imageTransfer(uint16_t* pUnpackedImage, char* filename);
+int saveImageToDisk(char* filename, peak_frame_handle hFrame);
+#endif
 int doCameraAndAstrometry();
 void clean();
 void closeCamera();

--- a/camera.h
+++ b/camera.h
@@ -14,17 +14,18 @@ extern HIDS camera_handle;
 #ifndef IDS_PEAK
 #define CAMERA_WIDTH   1936 // [px]
 #define CAMERA_HEIGHT  1216 // [px]
-// pixel scale search range bounds -> 6.0 to 6.5 for SO, 6.0 to 7.0 for BLAST
+// pixel scale search range bounds -> 6.0 to 6.5 for SO, 6.0 to 7.0 for BLAST,
 #define MIN_PS         6.0  // [arcsec/px]
 #define MAX_PS         7.0  // [arcsec/px]
 #else
 // TIMSC is IMX542
-// Datasheet says array is 5328 x 3040, but this includes overscan. The active
-// area is 8px smaller each side.
+// Datasheet says array is 5328 x 3040, but this includes overscan. The number
+// recommended recording pixels is an area is 8px smaller each side.
 #define CAMERA_WIDTH   5320 // [px]
 #define CAMERA_HEIGHT  3032 // [px]
-#define MIN_PS         14.0  // [arcsec/px]
-#define MAX_PS         15.0  // [arcsec/px]
+// ~6.63 for TIMSC with 85mm lens
+#define MIN_PS         6.0  // [arcsec/px]
+#define MAX_PS         7.0  // [arcsec/px]
 #endif
 #define CAMERA_MARGIN  0		 // [px]
 #define CAMERA_MAX_PIXVAL 4095 //  2**12
@@ -62,6 +63,76 @@ struct blob_params {
     int use_static_hp_mask;     // flag to use the current static hot pixel map
 };
 #pragma pack(pop)
+
+
+// There is no equivalent of iDS Software Suite sensorInfo, but it's useful for 
+// collecting info from multiple other structs, so re-implement some parts here.
+// A little preview: eventually sensor/capture data will be saved in headers of
+// FITS files.
+struct fits_metadata_t {
+
+    // Capture data
+
+    char origin[10]; // ORIGIN: program used to generate file
+    char instrume[10]; // INSTRUME: instrument name
+    char telescop[30]; // TELESCOP: lens name
+    char observat[10]; // OBSERVAT: observatory name
+    char observer[10]; // OBSERVER: observer name
+    char filename[200]; // FILENAME: basename + ext on disk
+    char date[200]; // DATE: time of file creation (UTC)
+    char utc_obs[200]; // UTC-OBS: time of observation start (UTC)
+    float julian; // JULIAN: Julian date of obs start
+    char filter[20]; // FILTER: fileter name
+    float ccdtemp; // CCDTEMP: camera temp (C)
+    int16_t focus; // FOCUS: focus position (encoder units)
+    int8_t aperture; // APERTURE: aperture position (10x fstop)
+    float exptime; // EXPTIME: total exposure time (s)
+    char bunit[4]; // BUNIT: physical unit of array values (ADU)
+
+    // Compression settings, not all are used for integer images
+    // https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node41.html
+
+    char fzalgor[12]; // FZALGOR  - 'RICE_1' , 'GZIP_1', 'GZIP_2', 'HCOMPRESS_1', 'PLIO_1', 'NONE'
+    char fztile[4]; // FZTILE   - 'ROW', 'WHOLE', or '(n,m)'
+
+    // Sensor settings
+
+    char detector[64]; // DETECTOR: sensor name
+    uint8_t bitdepth; // BITDEPTH: requested bit depth of camera, not equivalent to BITPIX
+    float pixscal1; // PIXSCAL1: plate scale, axis 1 (arcsec/px)
+    float pixscal2; // PIXSCAL2: plate scale, axis 2 (arcsec/px)
+    float pixsize1; // PIXSIZE1: pixel pitch, axis 1 (micron)
+    float pixsize2; // PIXSIZE2: pixel pitch, axis 2 (micron)
+    float darkcur; // DARKCUR: avg dark current (e-/px/s)
+    float rdnoise1; // RDNOISE1: read noise (e-)
+    uint8_t ccdbin1; // CCDBIN1: x-axis binning factor
+    uint8_t ccdbin2; // CCDBIN2: y-axis binning factor
+    uint8_t pixelclk; // PIXELCLK: pixel clock (MHz)
+    float framerte; // FRAMERTE: framerate (Hz)
+    float gainfact; // GAINFACT: iDS gain factor setting (e.g. 2.0x)
+    // GAIN1: sensor gain, e-/DN...depends on GAINFACT, not known a-priori unless calibrated
+    float trigdlay; // TRIGDLAY: trigger delay (ms)
+    uint16_t bloffset; // BLOFFSET: black level offset setting, arb units
+    int16_t autogain; // AUTOGAIN: automatic gain control on (1) off (0)
+    int16_t autoshut; // AUTOSHUT: automatic shutter control on (1) off (0)
+    int16_t autofrte; // AUTOFRTE: automatic framerate control on (1) off (0)
+    int16_t autoblk; // AUTOBLK: automatic black level offset on (1) off (0)
+
+    // TODO(evanmayer): add more WCS info fields?
+    // Pointing data (to be added on plate solve?)
+
+    // SITEELEV: altitude, m
+    // SITELAT: latitude, (DD:MM:SS.S N)
+    // SITELAT: latitude, (DD:MM:SS.S W)
+    // AIRMASS:
+    // AZIMUTH:
+    // ELEVAT:
+    // RA:
+    // DEC:
+    // ROTANGLE: image rotation angle
+    // EQUINOX: (epoch of RA,DEC)
+};
+
 
 extern struct blob_params all_blob_params;
 extern struct trigger_params all_trigger_params;

--- a/commands.c
+++ b/commands.c
@@ -752,9 +752,15 @@ int main(int argc, char * argv[]) {
         printf("Could not initialize camera due to above error. Could be that "
                "you specified a handle for a camera already in use.\n");
         // if camera was already initialized, close it before exiting
+        #ifndef IDS_PEAK
+        if (camera_handle > 0) {
+            closeCamera();
+        }
+        #else
         if (hCam > 0) {
             closeCamera();
         }
+        #endif
         close(sockfd);
         exit(EXIT_FAILURE);
     }

--- a/commands.c
+++ b/commands.c
@@ -394,7 +394,6 @@ void * processClient(void * for_client_thread) {
             break;
         } 
 
-
         if (send(socket, camera_raw, sizeof(camera_raw), 
                  MSG_NOSIGNAL) <= 0) {
             printf("Client dropped the connection.\n");

--- a/commands.c
+++ b/commands.c
@@ -1,19 +1,18 @@
-#include <sys/types.h>  
-#include <sys/socket.h> 
-#include <string.h>     
-#include <stdlib.h>     
-#include <netinet/in.h>     
-#include <stdio.h>          
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <stdlib.h> 
+#include <netinet/in.h>
+#include <stdio.h>
 #include <arpa/inet.h>
 #include <ifaddrs.h> 
-#include <netdb.h>         
-#include <errno.h>      
-#include <time.h>  
-#include <math.h>  
-#include <pthread.h>      
-#include <signal.h>         
-#include <ueye.h>
-#include <getopt.h>           
+#include <netdb.h>
+#include <errno.h>
+#include <time.h>
+#include <math.h>
+#include <pthread.h>
+#include <signal.h>
+#include <getopt.h> 
 
 #include "camera.h"
 #include "astrometry.h"
@@ -59,6 +58,23 @@ struct args {
     char * user_IP;
 };
 #pragma pack(pop)
+
+struct star_cam_capture FC1_in = {};
+struct star_cam_capture FC2_in = {};
+struct star_cam_return FC1_return = {};
+struct star_cam_return FC2_return = {};
+struct mcp_astrometry FC1_astro = {};
+struct mcp_astrometry FC2_astro = {};
+struct socket_data fc1Socket_listen = {};
+struct socket_data fc2Socket_listen = {};
+struct socket_data fc1Socket_trigger = {};
+struct socket_data fc2Socket_trigger = {};
+struct socket_data fc1_return_socket = {};
+struct socket_data fc2_return_socket = {};
+struct socket_data fc1_image_socket = {};
+struct socket_data fc2_image_socket = {};
+struct star_cam_trigger FC1_trigger = {};
+struct star_cam_trigger FC2_trigger = {};
 
 /* Pre-defined struct from getopt.h for additional long options */
 static const struct option long_options[] = {
@@ -635,12 +651,14 @@ int main(int argc, char * argv[]) {
     printf("|     \tSocket Port: %s     \t\t\t\t  |\n", port);
     printf("+---------------------------------------------------------+\n");
 
+    // NOTE(evanmayer): We don't allow the user to choose from multiple cameras,
+    // remove this option.
     // if the arguments exist, check their values are valid
-    camera_handle = atoi(handle);
-    if (camera_handle > 254 || camera_handle < 1) {
-        printf("Invalid camera handle. Choose one in the range 1-254.\n");
-        return 0;
-    }
+    // camera_handle = atoi(handle);
+    // if (camera_handle > 254 || camera_handle < 1) {
+    //     printf("Invalid camera handle. Choose one in the range 1-254.\n");
+    //     return 0;
+    // }
 
     if (atoi(port) > 65535 || atoi(port) < 0) {
         printf("Invalid TCP socket port. Choose one in the range 0-65535.\n");
@@ -718,12 +736,24 @@ int main(int argc, char * argv[]) {
         exit(EXIT_FAILURE);
     }
 
-    // initialize the camera with input ID
+    // // initialize the camera with input ID
+    // if (initCamera() < 0) {
+    //     printf("Could not initialize camera due to above error. Could be that "
+    //            "you specified a handle for a camera already in use.\n");
+    //     // if camera was already initialized, close it before exiting
+    //     if (camera_handle > 0) {
+    //         closeCamera();
+    //     }
+    //     close(sockfd);
+    //     exit(EXIT_FAILURE);
+    // }
+
+    // initialize the first available camera
     if (initCamera() < 0) {
         printf("Could not initialize camera due to above error. Could be that "
                "you specified a handle for a camera already in use.\n");
         // if camera was already initialized, close it before exiting
-        if (camera_handle > 0) {
+        if (hCam > 0) {
             closeCamera();
         }
         close(sockfd);

--- a/lens_adapter.c
+++ b/lens_adapter.c
@@ -61,9 +61,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <termios.h>
-#include <ueye.h>
 #include <math.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "lens_adapter.h"
 #include "camera.h"
@@ -95,7 +95,6 @@ char * birger_output, * buffer;
 int file_descriptor, default_focus;
 // global variables for solution to quadratic regression for auto-focusing
 double a, b, c;
-IMAGE_FILE_PARAMS ImageFileParams;
 
 /* Helper function to print a 1D array.
 ** Input: The array to be printed.
@@ -643,7 +642,7 @@ int adjustCameraHardware() {
         // change boolean to 0 so exposure isn't adjusted again until user sends
         //  another command
         all_camera_params.change_exposure_bool = 0;
-        ret = updateExposure(all_camera_params.exposure_time);
+        ret = setExposureTime(all_camera_params.exposure_time);
     }
 
     return ret;

--- a/lens_adapter.c
+++ b/lens_adapter.c
@@ -226,8 +226,8 @@ int initLensAdapter(char * path) {
 
     // open file descriptor with given path
     if ((file_descriptor = open(path, O_RDWR | O_NOCTTY)) < 0) {
-        fprintf(stderr, "Error opening file descriptor to input path: %s.\n", 
-                strerror(errno));
+        fprintf(stderr, "Error opening file descriptor to input path %s: %s.\n", 
+                path, strerror(errno));
         return -1;
     }
 
@@ -415,6 +415,12 @@ int beginAutoFocus() {
 */
 int defaultFocusPosition() {
     char focus_str_cmd[10];
+
+    // Always start by checking current focuser pos, to get correct delta.
+    if (runCommand("fp\r", file_descriptor, birger_output) == -1) {
+        printf("Failed to print the new focus position.\n");
+        return -1;
+    }
 
     printf("> Moving to default focus position..\n");
     printf("(*) Default focus = %d, all_camera_params.focus_position = %d, "
@@ -604,7 +610,7 @@ int adjustCameraHardware() {
     if (all_camera_params.max_aperture == 1) {
         // might as well change struct field here since we know what maximum 
         // aperture position is (don't have to get it with pa command)
-        all_camera_params.current_aperture = 28;
+        all_camera_params.current_aperture = 14; // Sigma 85mm f/1.4
 
         if (runCommand("mo\r", file_descriptor, birger_output) == -1) {
             printf("Setting the aperture to maximum fails.\n");

--- a/sc_listen.c
+++ b/sc_listen.c
@@ -8,11 +8,9 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <unistd.h>
 #include <pthread.h>
 #include <signal.h>
 #include <errno.h>
-#include <ueye.h>
 
 #include "sc_listen.h"
 #include "commands.h"
@@ -25,7 +23,8 @@ extern int cancelling_auto_focus;
 extern int shutting_down;
 extern int taking_image;
 
-
+struct socket_errors sock_status = {};
+struct comms_data thread_comms = {};
 
 
 void set_status(char * ip, char * listen, int value) {

--- a/sc_listen.c
+++ b/sc_listen.c
@@ -84,20 +84,6 @@ void set_status(char * ip, char * listen, int value) {
     return;
 }
 
-// function to check if aperture value is one of the allowed numbers
-int aperture_allowed(float aperture_value) {
-    static float allowed_apertures[] = {2.8, 3.0, 3.3, 3.6, 4.0, 4.3, 4.7, 5.1, 5.6, 6.1, 6.7, 7.3, 8.0, 8.7, 9.5, 10.3, 
-                          11.3, 12.3, 13.4, 14.6, 16.0, 17.4, 19.0, 20.7, 22.6, 24.6, 26.9, 29.3, 32.0};
-    int arrLen = sizeof allowed_apertures / sizeof allowed_apertures[0];
-    for (int i = 0; i < arrLen; i++)
-    {
-        if (allowed_apertures[i] == aperture_value) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
 int check_AF_params(struct star_cam_capture data) {
     // check to make sure the end-start is an integer multiple of step size
     int distance;

--- a/sc_listen.h
+++ b/sc_listen.h
@@ -27,7 +27,6 @@
 
 
 void set_status(char * ip, char * listen, int value);
-int aperture_allowed(float aperture_value);
 int check_AF_params(struct star_cam_capture data);
 void process_command_packet(struct star_cam_capture data);
 void *listen_thread(void *args);

--- a/sc_listen.h
+++ b/sc_listen.h
@@ -1,3 +1,6 @@
+#ifndef SC_LISTEN_H
+#define SC_LISTEN_H
+
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -23,27 +26,6 @@
 #define TARGET_INET_SELF "127.0.0.1"
 
 
-struct star_cam_capture FC1_in;
-struct star_cam_capture FC2_in;
-struct socket_data fc1Socket_listen;
-struct socket_data fc2Socket_listen;
-struct socket_data listenSelf;
-struct socket_errors sock_status;
-struct comms_data thread_comms;
-struct socket_data fc1_return_socket;
-struct socket_data fc2_return_socket;
-struct socket_data fc1_image_socket;
-struct socket_data fc2_image_socket;
-struct star_cam_return FC1_return;
-struct star_cam_return FC2_return;
-struct mcp_astrometry FC1_astro;
-struct mcp_astrometry FC2_astro;
-struct socket_data fc1Socket_trigger;
-struct socket_data fc2Socket_trigger;
-struct star_cam_trigger FC1_trigger;
-struct star_cam_trigger FC2_trigger;
-
-
 void set_status(char * ip, char * listen, int value);
 int aperture_allowed(float aperture_value);
 int check_AF_params(struct star_cam_capture data);
@@ -51,3 +33,5 @@ void process_command_packet(struct star_cam_capture data);
 void *listen_thread(void *args);
 void * trigger_thread(void* args);
 void process_trigger_packet(struct star_cam_trigger data);
+
+#endif

--- a/sc_send.c
+++ b/sc_send.c
@@ -8,11 +8,9 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <unistd.h>
 #include <pthread.h>
 #include <signal.h>
 #include <errno.h>
-#include <ueye.h>
 
 #include "sc_send.h"
 #include "commands.h"

--- a/sc_send.h
+++ b/sc_send.h
@@ -1,3 +1,6 @@
+#ifndef SC_SEND_H
+#define SC_SEND_H
+
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -23,3 +26,5 @@
 
 void *astrometry_data_thread(void *args);
 void *parameter_data_thread(void *args);
+
+#endif


### PR DESCRIPTION
## Task

We need to use the iDS peak API in order to communicate with U3-designated cameras. The sensor required for my updated star camera design is U3.

[iDS Peak FAQ](https://www.ids-imaging.us/support-faq.html?search=peak)

The iDS Peak "image transport layer" theoretically allows backwards-compatibility to older cameras, such as the one flown in FTS '24 or used by the Simons Observatory (UI-3260CP-M-GL Rev.2). That transport layer from iDS Peak to iDS Software Suite (legacy API) would require upgrading any SC computers' installed iDS Software Suite 4.92.0 --> >=4.95.

As additional mitigation, we have tagged a version of the software that worked with that sensor and the old API.

## Acceptance

* [x] Connects to U3-31N0CP-M-GL Rev. 2.2 camera
* [x] Parity between settings commanded before/after API switch
  * [x] Where API changes make this impossible, a comment explaining the equivalent feature or that none exists
* [x] Sufficient logging to reconstruct camera parameters that were in place after a run
* [x] Saves timestamped 12-bit images to disk
* [x] When code is compiled without `IDS_PEAK` defined, it still works with the old sensor. 

## Details

The iDS Peak User Manual is here: https://www.ids-imaging.us/manuals/ids-peak/ids-peak-user-manual/2.16.0/en/index.html
This explains how the cameras work, and generally what features are available. There are some specific programming examples.

The detailed API docs for C are here: https://www.ids-imaging.us/manuals/ids-peak/ids-peak-comfortsdk-documentation/2.16.0/en/index.html
These document the specific C API calls, data types, macros, and programming style guidelines.

These changes are currently conditionally compiled in with `#ifdef IDS_PEAK` or `#ifndef IDS_PEAK`, `#else`. When testing is done, I'll swap the conditional compile to make the new API the default, and the old API conditionally compiled in. After we have some stick time, we can clean out the old API.

Where there are equivalent pieces of code before/after the changes, I've commented in the old API next to the new to facilitate comparison. I'll remove these at the end of the review period.

In order to make this all more readable and make the switchover easier, I've functionalized a lot of the API with getter/setter functions. The API docs suggest a LOT of error checking, and I've taken that suggestion to heart. There's a pattern to a lot of the error checking, which is easy to pick up on. The functions abstract away the API somewhat, and hide the error checking "mess" from casual readers.

Note that I did a tabs -> 4 spaces conversion in VSCode. Sorry. So a bunch of lines are "changes" that shouldn't be hard to review. The review interface is good about highlighting these whitespaces changes at the beginning of lines.

## Follow-On Tasks

In order of priority:

* On-sky testing, would be great to see a plate solve
* We should try not to break the SC-GUI too much. Fix up any issues that arise in that as a consequence of this
* Fix #6, growing pains of larger sensor
* iDS Peak requires Ubuntu 22.04 or newer. We should create a disk image for the TIMcam flight with 24.04, which is the VM I've been testing on.
  * Install docs for that process:
    * OS install
    * API install
    * astrometry.net install
    * SOFA lib install
    * changing paths in CMake to get build to work
    * running instructions
    * autostart service instructions
* I have laid the groundwork for saving images as FITS files with metadata in the header. Do that
* Implement an image loader to load a dummy image from disk for testing
