### PR TITLE
Implement gain control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project ("commands"
 
 # If you install ids peak via the tar archive, you'll need to point to it here
 set(CMAKE_PREFIX_PATH "/home/starcam/ids-peak-with-ueyetl_2.16.0.0-457_amd64/lib/")
+set(CMAKE_C_FLAGS_RELEASE "-O3")
 set(CMAKE_C_FLAGS_DEBUG "-O0 -fno-omit-frame-pointer -ggdb -g3")
 
 # Create target executable

--- a/astrometry.c
+++ b/astrometry.c
@@ -152,6 +152,10 @@ int lostInSpace(double * star_x, double * star_y, double * star_mags, unsigned
     solver->funits_upper = MAX_PS;
     
     // set max number of sources
+    unsigned int original_num_blobs = num_blobs;
+    if (num_blobs > MAX_BLOBS) {
+        num_blobs = MAX_BLOBS;
+    }
     solver->endobj = num_blobs;
 
     // disallow tiny quads
@@ -316,7 +320,8 @@ int lostInSpace(double * star_x, double * star_y, double * star_mags, unsigned
         printf("|\t\tTelemetry\t\t\t\t  |\n");
         printf("|---------------------------------------------------------|\n");
         printf("|\tRaw time (sec): %.1f\t\t\t  |\n", all_astro_params.rawtime);
-        printf("|\tNumber of blobs found: %i\t\t\t  |\n", num_blobs);
+        printf("|\tNumber of blobs found: %i\t\t\t  |\n", original_num_blobs);
+        printf("|\tNumber of blobs used: %i\t\t\t  |\n", num_blobs);
         printf("|\tAstrometry RA (deg): %lf\t\t\t  |\n", ra);
         printf("|\tAstrometry DEC (deg): %lf\t\t\t  |\n", dec);
         printf("|\tObserved RA (deg): %lf\t\t\t  |\n", all_astro_params.ra);

--- a/camera.c
+++ b/camera.c
@@ -2668,26 +2668,6 @@ void boxcarFilterImage(uint16_t * ib, int i0, int j0, int i1, int j1, int r_f,
 //             kernel, kernelSize, filteredImage);
 // }
 
-// void filterN(
-//     uint16_t* inputBuffer,
-//     unsigned char* mask,
-//     float* filteredImage
-//     int N)
-// {
-//     int MAX_EVAL = 10;
-//     uint8_t kernelSize = 9;
-//     float kernel[9] = {1./16., 2./16., 1./16., 2./16., 4./16., 2./16., 1./16., 2./16., 1./16.};
-//     static float inputBufferFlt[CAMERA_WIDTH * CAMERA_HEIGHT] = {0.};
-//     for (unsigned int i = 0; i < CAMERA_WIDTH * CAMERA_HEIGHT) {
-//         inputBufferFlt[i] = (float)inputBuffer[i];
-//     }
-//     if (N > MAX_EVAL) {
-//         N = MAX_EVAL
-//     }
-//     while (N > 0) {
-//     }
-// }
-
 
 /* Function to find the blobs in an image.
 ** Inputs: The original image prior to processing (input_biffer), the dimensions

--- a/camera.c
+++ b/camera.c
@@ -19,8 +19,6 @@
 // #include "convolve.h"
 #include "fits_utils.h"
 
-#define MIN_BLOBS 4
-#define MAX_BLOBS 9999
 
 // #define AF_ALGORITHM_NEW
 
@@ -142,6 +140,8 @@ struct trigger_params all_trigger_params = {
     .trigger = 0, // not starting off triggered
     .trigger_mode = 0, // default to 
 };
+
+enum solver_state_t solver_state = UNINIT;
 
 
 /* Helper function to determine if a year is a leap year (2020 is a leap year).
@@ -2440,10 +2440,11 @@ void makeMask(uint16_t * ib, int i0, int j0, int i1, int j1, int x0, int y0,
                 // map y coordinate to image in memory from Kst blob
                 y_p[num_p] = CAMERA_HEIGHT - j; 
 
-                if (verbose) {
-                    printf("|\tCoordinates read from hp file: [%4i, %4i]\t  |\n", 
-                           i, j);
-                }
+                // TODO(evanmayer) figure out a less annoying way to report this
+                // if (verbose) {
+                //     printf("|\tCoordinates read from hp file: [%4i, %4i]\t  |\n", 
+                //            i, j);
+                // }
 
                 num_p++;
             }
@@ -2694,6 +2695,7 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
         fclose(f);
     }
 
+    solver_state = HOTPIX_MASK;
     makeMask(input_buffer, i0, j0, i1, j1, 0, 0, 0);
 
     double sx = 0, sx2 = 0;
@@ -2701,6 +2703,7 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
     double sx_raw = 0;                            
     int num_pix = 0;
 
+    solver_state = FILTERING;
     // lowpass filter the image - reduce noise.
     boxcarFilterImage(input_buffer, i0, j0, i1, j1, all_blob_params.r_smooth, 
                       ic);
@@ -2825,6 +2828,8 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
     // And really, when are we ever going to see thousands, or even hundreds of
     // stars? And are those extra few hundred stars going to improve
     // performance? No.
+
+    solver_state = BLOB_FIND;
 
     // find the blobs 
     double ic0;
@@ -3388,6 +3393,7 @@ int doCameraAndAstrometry(void)
     }
 
     if (first_time) {
+        solver_state = INIT;
         output_buffer = calloc(CAMERA_WIDTH*CAMERA_HEIGHT, sizeof(uint16_t));
         if (output_buffer == NULL) {
             fprintf(stderr, "Error allocating output buffer: %s.\n", 
@@ -3547,6 +3553,7 @@ int doCameraAndAstrometry(void)
                 "/home/starcam/Desktop/TIMSC/latest_auto_focus_data.txt");
     }
 
+    solver_state = IMAGE_CAP;
     taking_image = 1;
     // Ian Lowe, 1/9/24, adding new logic to look for a trigger from a FC or sleep instead
     if (all_trigger_params.trigger_mode == 1) {
@@ -3678,6 +3685,7 @@ int doCameraAndAstrometry(void)
     // now have to distinguish between auto-focusing actions and solving
     // ECM N.B.: If AF_ALGORITHM_NEW defined, you'll never go in here
     if (all_camera_params.focus_mode && !all_camera_params.begin_auto_focus) {
+        solver_state = AUTOFOCUS;
         int brightest_blob, max_flux, focus_step;
         int brightest_blob_x, brightest_blob_y = 0;
         char focus_str_cmd[10];
@@ -3848,6 +3856,7 @@ int doCameraAndAstrometry(void)
             printf("\n> Trying to solve astrometry...\n");
         }
 
+        solver_state = ASTROMETRY;
         if (lostInSpace(star_x, star_y, star_mags, blob_count, tm_info, 
                         datafile) != 1) {
             printf("\n(*) Could not solve Astrometry.\n");

--- a/camera.c
+++ b/camera.c
@@ -141,7 +141,7 @@ struct trigger_params all_trigger_params = {
     .trigger_mode = 0, // default to 
 };
 
-enum solver_state_t solver_state = UNINIT;
+enum solveState_t solveState = UNINIT;
 
 
 /* Helper function to determine if a year is a leap year (2020 is a leap year).
@@ -2527,10 +2527,10 @@ void makeMask(uint16_t * ib, int i0, int j0, int i1, int j1, int x0, int y0,
 
         for (int i = 0; i < num_p; i++) {
             // set all static hot pixels to 0
-            if (verbose) {
-                printf("|\tCoordinates going into mask: [%4i, %4i]\t  |\n", 
-                       x_p[i], CAMERA_HEIGHT - y_p[i]);
-            }
+            // if (verbose) {
+            //     printf("|\tCoordinates going into mask: [%4i, %4i]\t  |\n", 
+            //            x_p[i], CAMERA_HEIGHT - y_p[i]);
+            // }
 
             int ind = CAMERA_WIDTH * y_p[i] + x_p[i];
             mask[ind] = 0;
@@ -2661,6 +2661,7 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
     
     b = all_blob_params.centroid_search_border;
 
+    solveState = HOTPIX_MASK;
     // if we want to make a new hot pixel mask
     if (all_blob_params.make_static_hp_mask) {
         if (verbose) {
@@ -2695,7 +2696,6 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
         fclose(f);
     }
 
-    solver_state = HOTPIX_MASK;
     makeMask(input_buffer, i0, j0, i1, j1, 0, 0, 0);
 
     double sx = 0, sx2 = 0;
@@ -2703,7 +2703,7 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
     double sx_raw = 0;                            
     int num_pix = 0;
 
-    solver_state = FILTERING;
+    solveState = FILTERING;
     // lowpass filter the image - reduce noise.
     boxcarFilterImage(input_buffer, i0, j0, i1, j1, all_blob_params.r_smooth, 
                       ic);
@@ -2829,7 +2829,7 @@ int findBlobs(uint16_t * input_buffer, int w, int h, double ** star_x,
     // stars? And are those extra few hundred stars going to improve
     // performance? No.
 
-    solver_state = BLOB_FIND;
+    solveState = BLOB_FIND;
 
     // find the blobs 
     double ic0;
@@ -3393,7 +3393,7 @@ int doCameraAndAstrometry(void)
     }
 
     if (first_time) {
-        solver_state = INIT;
+        solveState = INIT;
         output_buffer = calloc(CAMERA_WIDTH*CAMERA_HEIGHT, sizeof(uint16_t));
         if (output_buffer == NULL) {
             fprintf(stderr, "Error allocating output buffer: %s.\n", 
@@ -3553,7 +3553,7 @@ int doCameraAndAstrometry(void)
                 "/home/starcam/Desktop/TIMSC/latest_auto_focus_data.txt");
     }
 
-    solver_state = IMAGE_CAP;
+    solveState = IMAGE_CAP;
     taking_image = 1;
     // Ian Lowe, 1/9/24, adding new logic to look for a trigger from a FC or sleep instead
     if (all_trigger_params.trigger_mode == 1) {
@@ -3685,7 +3685,7 @@ int doCameraAndAstrometry(void)
     // now have to distinguish between auto-focusing actions and solving
     // ECM N.B.: If AF_ALGORITHM_NEW defined, you'll never go in here
     if (all_camera_params.focus_mode && !all_camera_params.begin_auto_focus) {
-        solver_state = AUTOFOCUS;
+        solveState = AUTOFOCUS;
         int brightest_blob, max_flux, focus_step;
         int brightest_blob_x, brightest_blob_y = 0;
         char focus_str_cmd[10];
@@ -3856,7 +3856,7 @@ int doCameraAndAstrometry(void)
             printf("\n> Trying to solve astrometry...\n");
         }
 
-        solver_state = ASTROMETRY;
+        solveState = ASTROMETRY;
         if (lostInSpace(star_x, star_y, star_mags, blob_count, tm_info, 
                         datafile) != 1) {
             printf("\n(*) Could not solve Astrometry.\n");

--- a/camera.c
+++ b/camera.c
@@ -463,7 +463,7 @@ int getMonoAnalogGain(double* pAnalogGain)
  * Side effect: updates metadata struct
  * 
  * @param analogGain multiplicative factor applied to the base gain
- * @return int 
+ * @return int -1 if failed, 0 otherwise
  */
 int setMonoAnalogGain(double analogGain)
 {

--- a/camera.h
+++ b/camera.h
@@ -29,6 +29,8 @@ extern HIDS camera_handle;
 #endif
 #define CAMERA_MARGIN  0		 // [px]
 #define CAMERA_MAX_PIXVAL 4095 //  2**12
+#define MIN_BLOBS 4
+#define MAX_BLOBS 300
 #define STATIC_HP_MASK "/home/starcam/Desktop/TIMSC/static_hp_mask.txt"
 #define dut1           -0.23
 
@@ -45,6 +47,20 @@ struct trigger_params
     int trigger; // 1 to take image if trigger mode is 1
     int trigger_timeout_us; // time in µs to wait between checks for a trigger
 };
+
+enum solver_state_t
+{
+    UNINIT,
+    INIT,
+    IMAGE_CAP,
+    HOTPIX_MASK,
+    FILTERING,
+    BLOB_FIND,
+    AUTOFOCUS,
+    ASTROMETRY,
+    NUM_STATES
+};
+extern enum solver_state_t solver_state;
 
 
 /* Blob-finding parameters */

--- a/camera.h
+++ b/camera.h
@@ -53,6 +53,7 @@ enum solveState_t
     UNINIT,
     INIT,
     IMAGE_CAP,
+    IMAGE_XFER,
     HOTPIX_MASK,
     FILTERING,
     BLOB_FIND,
@@ -101,6 +102,7 @@ int saveImageToDisk(char* filename);
 int getFps(double* pCurrentFps);
 int imageTransfer(uint16_t* pUnpackedImage);
 int saveImageToDisk(char* filename, peak_frame_handle hFrame);
+int setMonoAnalogGain(double analogGain);
 #endif
 int doCameraAndAstrometry();
 void clean();

--- a/camera.h
+++ b/camera.h
@@ -48,7 +48,7 @@ struct trigger_params
     int trigger_timeout_us; // time in µs to wait between checks for a trigger
 };
 
-enum solver_state_t
+enum solveState_t
 {
     UNINIT,
     INIT,
@@ -60,7 +60,7 @@ enum solver_state_t
     ASTROMETRY,
     NUM_STATES
 };
-extern enum solver_state_t solver_state;
+extern enum solveState_t solveState;
 
 
 /* Blob-finding parameters */

--- a/commands.c
+++ b/commands.c
@@ -806,6 +806,11 @@ int main(int argc, char * argv[]) {
            num_clients);
         printf("+---------------------------------------------------------+\n");
 
+        // Inform the user of the processing state
+        if (verbose) {
+            printf("Current state: %d", solver_state);
+        }
+
         // store length of client that has connected (if any)
         client_addr_len = sizeof(client_addr);
         if (newsockfd == -1) {

--- a/commands.c
+++ b/commands.c
@@ -89,6 +89,18 @@ static const struct option long_options[] = {
     { NULL,        no_argument,       NULL,  0  },
 };
 
+// Helper for printing state machine states
+const char* solveStateStr[NUM_STATES] = {
+    "Uninitialized",
+    "Initializing",
+    "Image Capture",
+    "Hot Pixel Masking",
+    "Filtering",
+    "Blob Finding",
+    "Autofocus",
+    "Astrometry"
+};
+
 struct commands all_cmds = {0};
 struct telemetry all_data = {0};
 int num_clients = 0;
@@ -808,7 +820,9 @@ int main(int argc, char * argv[]) {
 
         // Inform the user of the processing state
         if (verbose) {
-            printf("Current state: %d", solver_state);
+            printf("+=========================================================+\n");
+            printf("| Current state: %s\n", solveStateStr[solveState]);
+            printf("+=========================================================+\n");
         }
 
         // store length of client that has connected (if any)

--- a/commands.c
+++ b/commands.c
@@ -36,6 +36,7 @@ struct commands {
     double longitude;       // user's longitude (degrees)
     double height;          // user's height above ellipsoid from GPS (WGS84)
     double exposure;        // user's desired camera exposure (msec)
+    double gainfact;        // user's desired gain factor (x times base gain DN/e-)
     double timelimit;       // Astrometry tries to solve until this timeout
     float focus_pos;        // user's desired focus position (counts)
     int focus_mode;         // flag to enter auto-focusing mode
@@ -94,6 +95,7 @@ const char* solveStateStr[NUM_STATES] = {
     "Uninitialized",
     "Initializing",
     "Image Capture",
+    "Image Transfer",
     "Hot Pixel Masking",
     "Filtering",
     "Blob Finding",
@@ -169,6 +171,7 @@ void verifyUserCommands() {
     printf("|\tLatitude | longitude: %f | %f\t  |\n", all_cmds.latitude, 
                                               all_cmds.longitude);
     printf("|\tExposure command in commands.c: %f\t  |\n", all_cmds.exposure);
+    printf("|\tGain command in commands.c: %f\t\t\t  |\n", all_cmds.gainfact);
     printf("|\tAstrometry timeout: %f\t\t\t  |\n", all_cmds.timelimit);
     printf("|\tFocus mode: %s\t\t\t  |\n", (all_cmds.focus_mode) ? 
            "Auto-focus" : "Normal focus");
@@ -351,6 +354,13 @@ void * processClient(void * for_client_thread) {
                     // update value in camera params struct as well
                     all_camera_params.exposure_time = all_cmds.exposure;
                     all_camera_params.change_exposure_bool = 1;
+                }
+
+                // if user adjusted gain, set gainfact to their value
+                if (fabs(all_cmds.gainfact - all_camera_params.gainfact) > 1E-9) {
+                    // update value in camera params struct as well
+                    all_camera_params.gainfact = all_cmds.gainfact;
+                    all_camera_params.change_gainfact_bool = 1;
                 }
 
                 // contradictory commands between setting focus to inf and 

--- a/convolve.c
+++ b/convolve.c
@@ -25,19 +25,17 @@ uint16_t average(uint16_t* data, uint32_t n)
  * 
  * @details Supplied arrays are accessed in C row-major order. In row-major 
  * order, left/right adjacent pixels are adjacent in the array, while top/
- * bottom pixels are `imageWidth` indices apart. For edge cases, place 0s in
- * `neighborhood`, to zero out that term in convolution.
+ * bottom pixels are `imageWidth` indices apart. For edge cases, return the
+ * nearest valid neighbor.
  * @param[in] imageBuffer contiguous memory containing original pixel values
- * @param imageMean mean value of image, for proper handling of edges
  * @param pixelIndex raw row-major index into image memory
  * @param imageWidth number of columns in a single image row
  * @param imageNumPix number of columns x number of rows in image
  * @param[out] neighborhood 9-element array containing 3x3 block of pixels around
  * `pixelIndex`
  */
-void getNeighborhood(
+void getNeighborhoodNearest(
     uint16_t* imageBuffer,
-    uint16_t imageMean,
     uint32_t pixelIndex,
     uint16_t imageWidth,
     uint32_t imageNumPix,
@@ -48,42 +46,134 @@ void getNeighborhood(
     bool isBottom = ((int64_t)pixelIndex - imageWidth) < 0;
     bool isTop = (pixelIndex + imageWidth) >= imageNumPix;
 
-    // HACK: FIXME: sobelmetric returns to 0 when high?
-    imageMean = 0U;
+    // DOWN is more negative
+    // LEFT is more negative
+    //  --------------  //  --------------
+    // | 6  | 7  | 8  | // | TL | T  | TR |
+    // |----|----|----| // |----|----|----|
+    // | 3  | 4  | 5  | // | L  | C  | R  |
+    // |----|----|----| // |----|----|----|
+    // | 0  | 1  | 2  | // | BL | B  | BR |
+    //  --------------  //  --------------
+    uint32_t idxTL = pixelIndex + imageWidth - 1;
+    uint32_t idxT = pixelIndex + imageWidth;
+    uint32_t idxTR = pixelIndex + imageWidth + 1;
+    uint32_t idxL = pixelIndex - 1;
+    uint32_t idxC = pixelIndex;
+    uint32_t idxR = pixelIndex + 1;
+    uint32_t idxBL = pixelIndex - imageWidth - 1;
+    uint32_t idxB = pixelIndex - imageWidth;
+    uint32_t idxBR = pixelIndex - imageWidth + 1;
 
-    // If not blocked by image bound guards, return pixel value, else return image mean value
-    neighborhood[0] = (!isBottom && !isLeft)     ? imageBuffer[pixelIndex - imageWidth - 1] : imageMean;
-    neighborhood[1] = (!isBottom)                ? imageBuffer[pixelIndex - imageWidth]     : imageMean;
-    neighborhood[2] = (!isBottom && !isRight)    ? imageBuffer[pixelIndex - imageWidth + 1] : imageMean;
-    neighborhood[3] = (!isLeft)                  ? imageBuffer[pixelIndex - 1]              : imageMean;
-    // ought to be limited by caller's for loop, but belt & suspenders
-    neighborhood[4] = (pixelIndex < imageNumPix) ? imageBuffer[pixelIndex]                  : imageMean;
-    neighborhood[5] = (!isRight)                 ? imageBuffer[pixelIndex + 1]              : imageMean;
-    neighborhood[6] = (!isTop && !isLeft)        ? imageBuffer[pixelIndex + imageWidth - 1] : imageMean;
-    neighborhood[7] = (!isTop)                   ? imageBuffer[pixelIndex + imageWidth]     : imageMean;
-    neighborhood[8] = (!isTop && !isRight)       ? imageBuffer[pixelIndex + imageWidth + 1] : imageMean;
-}
-
-
-/**
- * @brief The innermost part of the convolution algorithm, add-and-multiply
- * pixels by kernel elements.
- * 
- * @param[in] array the input array to be considered; intended to be the output of
- * `getNeighborhood`
- * @param kernel the convolution kernel. Don't pass arrays of other types in
- * here, you heathen.
- * @param kernelSize the length of the flattened, square kernel
- * @return the result of the convolution
- */
-float convolve(uint16_t* array, int16_t* kernel, uint8_t kernelSize)
-{
-    float sum = 0;
-    // Assumption: array and kernel are same size.
-    for (uint8_t i = 0; i < kernelSize; i++) {
-        sum += (float)array[i] * (float)kernel[kernelSize - i - 1];
+    if (isBottom && isLeft) {
+        neighborhood[0] = imageBuffer[idxC];
+        neighborhood[1] = imageBuffer[idxC];
+        neighborhood[2] = imageBuffer[idxR];
+        neighborhood[3] = imageBuffer[idxC];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxR];
+        neighborhood[6] = imageBuffer[idxT];
+        neighborhood[7] = imageBuffer[idxT];
+        neighborhood[8] = imageBuffer[idxTR];
+        return;
     }
-    return sum;
+    if (isBottom && !isLeft && !isRight) {
+        neighborhood[0] = imageBuffer[idxL];
+        neighborhood[1] = imageBuffer[idxC];
+        neighborhood[2] = imageBuffer[idxR];
+        neighborhood[3] = imageBuffer[idxL];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxR];
+        neighborhood[6] = imageBuffer[idxTL];
+        neighborhood[7] = imageBuffer[idxT];
+        neighborhood[8] = imageBuffer[idxTR];
+        return;
+    }
+    if (isBottom && isRight) {
+        neighborhood[0] = imageBuffer[idxL];
+        neighborhood[1] = imageBuffer[idxC];
+        neighborhood[2] = imageBuffer[idxC];
+        neighborhood[3] = imageBuffer[idxL];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxC];
+        neighborhood[6] = imageBuffer[idxTL];
+        neighborhood[7] = imageBuffer[idxT];
+        neighborhood[8] = imageBuffer[idxT];
+        return;
+    }
+    if (isLeft && !isTop && !isBottom) {
+        neighborhood[0] = imageBuffer[idxB];
+        neighborhood[1] = imageBuffer[idxB];
+        neighborhood[2] = imageBuffer[idxBR];
+        neighborhood[3] = imageBuffer[idxC];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxR];
+        neighborhood[6] = imageBuffer[idxT];
+        neighborhood[7] = imageBuffer[idxT];
+        neighborhood[8] = imageBuffer[idxTR];
+        return;
+    }
+    if (!isLeft && !isBottom && !isRight && !isTop) {
+        // We're just normal men...we're just ordinary men...
+        neighborhood[0] = imageBuffer[idxBL];
+        neighborhood[1] = imageBuffer[idxB];
+        neighborhood[2] = imageBuffer[idxBR];
+        neighborhood[3] = imageBuffer[idxL];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxR];
+        neighborhood[6] = imageBuffer[idxTL];
+        neighborhood[7] = imageBuffer[idxT];
+        neighborhood[8] = imageBuffer[idxTR];
+        return;
+    }
+    if (isRight && !isTop && !isBottom) {
+        neighborhood[0] = imageBuffer[idxBL];
+        neighborhood[1] = imageBuffer[idxB];
+        neighborhood[2] = imageBuffer[idxB];
+        neighborhood[3] = imageBuffer[idxL];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxC];
+        neighborhood[6] = imageBuffer[idxTL];
+        neighborhood[7] = imageBuffer[idxT];
+        neighborhood[8] = imageBuffer[idxT];
+        return;
+    }
+    if (isTop && isLeft) {
+        neighborhood[0] = imageBuffer[idxB];
+        neighborhood[1] = imageBuffer[idxB];
+        neighborhood[2] = imageBuffer[idxBR];
+        neighborhood[3] = imageBuffer[idxC];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxR];
+        neighborhood[6] = imageBuffer[idxC];
+        neighborhood[7] = imageBuffer[idxC];
+        neighborhood[8] = imageBuffer[idxR];
+        return;
+    }
+    if (isTop && !isLeft && !isRight) {
+        neighborhood[0] = imageBuffer[idxBL];
+        neighborhood[1] = imageBuffer[idxB];
+        neighborhood[2] = imageBuffer[idxBR];
+        neighborhood[3] = imageBuffer[idxL];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxR];
+        neighborhood[6] = imageBuffer[idxL];
+        neighborhood[7] = imageBuffer[idxC];
+        neighborhood[8] = imageBuffer[idxR];
+        return;
+    }
+    if (isTop && isRight) {
+        neighborhood[0] = imageBuffer[idxBL];
+        neighborhood[1] = imageBuffer[idxB];
+        neighborhood[2] = imageBuffer[idxB];
+        neighborhood[3] = imageBuffer[idxL];
+        neighborhood[4] = imageBuffer[idxC];
+        neighborhood[5] = imageBuffer[idxC];
+        neighborhood[6] = imageBuffer[idxL];
+        neighborhood[7] = imageBuffer[idxC];
+        neighborhood[8] = imageBuffer[idxC];
+        return;
+    }
 }
 
 
@@ -145,7 +235,7 @@ void doConvolution(
     // statically allocate this array for (re)use throughout the run
     uint16_t neighborhood[9] = {0};
     for (uint32_t i = 0; i < imageNumPix; i++) {
-        getNeighborhood(imageBuffer, imageMean, i, imageWidth, imageNumPix, neighborhood);
+        getNeighborhoodNearest(imageBuffer, i, imageWidth, imageNumPix, neighborhood);
         imageResult[i] = convolve9(neighborhood, kernel) * (float)(mask[i]);
     }
 }

--- a/convolve.h
+++ b/convolve.h
@@ -4,14 +4,6 @@
 #include <stddef.h>
 
 uint16_t average(uint16_t* data, uint32_t n);
-void getNeighborhood(
-    uint16_t* imageBuffer,
-    uint16_t imageMean,
-    uint32_t pixelIndex,
-    uint16_t imageWidth,
-    uint32_t imageNumPix,
-    uint16_t* neighborhood);
-float convolve(uint16_t* array, int16_t* kernel, uint8_t kernelSize);
 void doConvolution(
     uint16_t* imageBuffer,
     uint16_t imageMean,

--- a/lens_adapter.c
+++ b/lens_adapter.c
@@ -82,13 +82,15 @@ struct camera_params all_camera_params = {
     .max_focus_pos = 0,        // current max focus position
     .exposure_time = 100,      // current exposure time (800 msec is default)
     .change_exposure_bool = 0, // does user want to change exposure
+    .gainfact = 1.0,           // current gain factor (1.0 is default)
+    .change_gainfact_bool = 0, // does user want to change gain factor
     .begin_auto_focus = 1,     // auto-focus at beginning of camera's run
     .focus_mode = 0,           // camera begins in auto-focusing mode by default
     .start_focus_pos = 0,      // starting focus for auto-focusing search
     .end_focus_pos = 0,        // ending focus position also set below
     .focus_step = 5,           // by default, check every fifth focus position
     .photos_per_focus = 3,     // take 3 pictures per focus position by default
-    .flux = 0,                 // first auto-focus max flux found will set this
+    .flux = 0.0,                 // first auto-focus max flux found will set this
 };
 
 char * birger_output, * buffer;
@@ -649,6 +651,13 @@ int adjustCameraHardware() {
         //  another command
         all_camera_params.change_exposure_bool = 0;
         ret = setExposureTime(all_camera_params.exposure_time);
+    }
+
+    if (all_camera_params.change_gainfact_bool) {
+        // change boolean to 0 so gain isn't adjusted again until user sends
+        // another command
+        all_camera_params.change_gainfact_bool = 0;
+        ret = setMonoAnalogGain(all_camera_params.gainfact);
     }
 
     return ret;

--- a/lens_adapter.h
+++ b/lens_adapter.h
@@ -24,7 +24,9 @@ struct camera_params {
     // camera parameter, not lens parameter, but adjustments to it are made in 
     // lens_adapter.c
     double exposure_time;
-    double change_exposure_bool;
+    int change_exposure_bool;
+    double gainfact;
+    int change_gainfact_bool;
     // auto-focusing parameters & data
     int begin_auto_focus;       // flag to enter auto-focusing
     int focus_mode;             // state of auto-focusing (1 = on, 0 = off)
@@ -32,7 +34,7 @@ struct camera_params {
     int end_focus_pos;          // where to end the auto-focusing process
     int focus_step;             // granularity of auto-focusing checker
     int photos_per_focus;       // number of photos per auto-focusing position
-    int flux;                   // brightness of most recent maximum flux
+    double flux;                   // brightness of most recent maximum flux
 };
 #pragma pack(pop)
 

--- a/sc_data_structures.h
+++ b/sc_data_structures.h
@@ -76,6 +76,8 @@ struct star_cam_capture {
     int update_height; // is this a new commanded value?
     double exposureTime; // milliseconds
     int update_exposureTime; // is this a new commanded value?
+    double gainFact; // x times base gain in DN/e-
+    int update_gainFact;
     double solveTimeLimit; // time allowed to solve an image
     int update_solveTimeLimit; // is this a new commanded value?
     float focusPos; // desired focus position, encoder units
@@ -133,6 +135,7 @@ struct star_cam_return {
     double longitude; // payload long
     double heightWGS84; // payload alt above reference surface
     double exposureTime; // milliseconds
+    double gainFact; // x times base gain factor in DN/e-
     double solveTimeLimit; // time allowed to solve an image
     float focusPos; // desired focus position, encoder units
     int minFocusPos;

--- a/sc_listen.c
+++ b/sc_listen.c
@@ -238,6 +238,22 @@ void process_command_packet(struct star_cam_capture data){
                        "commands.\n");
             }
         }
+        if (data.update_gainFact == 1)
+        {
+            printf("Received update to GAIN parameter\n");
+            if (!all_camera_params.focus_mode && !cancelling_auto_focus) {
+                // if user adjusted gain, set gainfact to their value
+                if (fabs(data.gainFact - all_camera_params.gainfact) > 1E-9) {
+                    // update value in camera params struct as well
+                    all_camera_params.gainfact = data.gainFact;
+                    all_camera_params.change_gainfact_bool = 1;
+                }
+            } else {
+                printf("In or entering auto-focusing mode, or cancelling "
+                       "current auto-focus process, so ignore lens " 
+                       "commands.\n");
+            }
+        }
         if (data.update_setFocusInf == 1)
         {
             printf("Received update to SET FOCUS INF parameter\n");

--- a/sc_send.c
+++ b/sc_send.c
@@ -42,6 +42,7 @@ static int populate_parameter_packet(struct star_cam_return * packet_data) {
     packet_data->longitude = all_astro_params.longitude;
     packet_data->heightWGS84 = all_astro_params.hm;
     packet_data->exposureTime = all_camera_params.exposure_time;
+    packet_data->gainFact = all_camera_params.gainfact;
     packet_data->solveTimeLimit = all_astro_params.timelimit;
     packet_data->focusMode = all_camera_params.focus_position;
     packet_data->minFocusPos = all_camera_params.min_focus_pos;

--- a/tests/test_convolve.c
+++ b/tests/test_convolve.c
@@ -7,10 +7,10 @@
 
 #include "../convolve.h"
 
-// #define IMAGE_WIDTH 5320
-// #define IMAGE_HEIGHT 3032
-#define IMAGE_WIDTH 11
-#define IMAGE_HEIGHT 11
+#define IMAGE_WIDTH 5320
+#define IMAGE_HEIGHT 3032
+//#define IMAGE_WIDTH 11
+//#define IMAGE_HEIGHT 11
 
 uint16_t imageBuffer[IMAGE_WIDTH * IMAGE_HEIGHT] = {0};
 unsigned char mask[IMAGE_WIDTH * IMAGE_HEIGHT] = {0};


### PR DESCRIPTION
### Summary

In order to completely control imaging performance, we must be able to control the analog gain. Implement control of the gain setting via GUI command packets and flight computer command packets.

### Details

CMOS sensors have analog amplifiers for each pixel. The amplifier gain is the conversion factor of photoelectrons to ADC counts by the gain in ADU/e-. Increasing the gain of the amplifier can more effectively use the analog-to-digital converter (ADC) bits in the presence of low light or small light level variations that may be below the quantization level of the ADC. Increasing gain applies a multiplicative factor to the "base gain," so increasing the gain means that a given electron count will result in a greater change in ADC value, thereby effectively reducing quantization errors at the cost of reducing dynamic range.

iDS sensors typically have an analog gain factor range from 1-~16, which our gain requests must obey.