### PR TITLE
Add number of blobs found to telemetry

### DIFF
--- a/astrometry.c
+++ b/astrometry.c
@@ -37,6 +37,7 @@ struct mcp_astrometry mcp_astro;
 struct astrometry all_astro_params = {
     .timelimit = 1,
     .rawtime = 0,
+    .numBlobsFound = 0,
     .logodds = 1e8,
     .latitude = backyard_lat,
     .longitude = backyard_long,
@@ -157,6 +158,7 @@ int lostInSpace(double * star_x, double * star_y, double * star_mags, unsigned
         num_blobs = MAX_BLOBS;
     }
     solver->endobj = num_blobs;
+    all_astro_params.numBlobsFound = original_num_blobs;
 
     // disallow tiny quads
     solver->quadsize_min = 0.1*MIN(CAMERA_WIDTH - 2*CAMERA_MARGIN, 
@@ -304,6 +306,9 @@ int lostInSpace(double * star_x, double * star_y, double * star_mags, unsigned
         mcp_astro.dec_observed = dob*(180.0/M_PI);
         mcp_astro.ra_observed = rob*(180.0/M_PI);
         mcp_astro.image_rms = sigma_pointing_as;
+        // ECM: unsure if mcp_astro is even being used, since
+        // populate_astrometry_packet() exists and pulls from all_astro_params
+        mcp_astro.numBlobsFound = original_num_blobs;
         // update astro struct with telemetry
         all_astro_params.dec_j2000 = dec;
         all_astro_params.ra_j2000 = ra;

--- a/astrometry.h
+++ b/astrometry.h
@@ -12,6 +12,7 @@ int lostInSpace(double * star_x, double * star_y, double * star_mags,
 struct astrometry {
     double timelimit;
     double rawtime;
+    unsigned int numBlobsFound;
     // for solving altaz
     double logodds;
     double latitude;

--- a/convolve.c
+++ b/convolve.c
@@ -193,18 +193,18 @@ void getNeighborhoodNearest(
  * here, you heathen.
  * @return the result of the convolution
  */
-float convolve9(uint16_t* array, int16_t* kernel)
+float convolve9(uint16_t* array, float* kernel)
 {
     return (
-        (float)array[0] * (float)kernel[8] +
-        (float)array[1] * (float)kernel[7] +
-        (float)array[2] * (float)kernel[6] +
-        (float)array[3] * (float)kernel[5] +
-        (float)array[4] * (float)kernel[4] +
-        (float)array[5] * (float)kernel[3] +
-        (float)array[6] * (float)kernel[2] +
-        (float)array[7] * (float)kernel[1] +
-        (float)array[8] * (float)kernel[0]
+        (float)array[0] * kernel[8] +
+        (float)array[1] * kernel[7] +
+        (float)array[2] * kernel[6] +
+        (float)array[3] * kernel[5] +
+        (float)array[4] * kernel[4] +
+        (float)array[5] * kernel[3] +
+        (float)array[6] * kernel[2] +
+        (float)array[7] * kernel[1] +
+        (float)array[8] * kernel[0]
     );
 }
 
@@ -220,7 +220,6 @@ float convolve9(uint16_t* array, int16_t* kernel)
  * noise like PMCs, a variable-radius filter is required.
  * 
  * @param[in] imageBuffer
- * @param imageMean
  * @param imageWidth 
  * @param imageNumPix 
  * @param[in] mask hot pixel mask, whether or not to include pixel in calculations
@@ -230,11 +229,10 @@ float convolve9(uint16_t* array, int16_t* kernel)
  */
 void doConvolution(
     uint16_t* imageBuffer,
-    uint16_t imageMean,
     uint16_t imageWidth,
     uint32_t imageNumPix,
     unsigned char* mask,
-    int16_t* kernel,
+    float* kernel,
     uint8_t kernelSize,
     float* imageResult)
 {

--- a/convolve.h
+++ b/convolve.h
@@ -6,10 +6,9 @@
 uint16_t average(uint16_t* data, uint32_t n);
 void doConvolution(
     uint16_t* imageBuffer,
-    uint16_t imageMean,
     uint16_t imageWidth,
     uint32_t imageNumPix,
     unsigned char* mask,
-    int16_t* kernel,
+    float* kernel,
     uint8_t kernelSize,
     float* imageResult);

--- a/sc_data_structures.h
+++ b/sc_data_structures.h
@@ -39,6 +39,7 @@ struct mcp_astrometry {
     double alt;
     double az;
     double photo_time;
+    unsigned int numBlobsFound; // number of blobs found in image
 };
 
 struct comms_data {

--- a/sc_send.c
+++ b/sc_send.c
@@ -32,6 +32,7 @@ static int populate_astrometry_packet(struct mcp_astrometry * packet_data) {
     packet_data->ra_j2000 = all_astro_params.ra_j2000;
     packet_data->ra_observed = all_astro_params.ra;
     packet_data->rawtime = all_astro_params.rawtime;
+    packet_data->numBlobsFound = all_astro_params.numBlobsFound;
     return 1;
 }
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 dummyArray.csv
 test.fits.gz
+*.fits

--- a/tests/test_convolve.c
+++ b/tests/test_convolve.c
@@ -52,11 +52,11 @@ int main(int argc, char* argv[]) {
     }
     imageBuffer[imageNumPix / 2] = 100;
 
-    uint16_t kernel[9] = {1, 2, 1, 2, 4, 2, 1, 2, 1}; // gaussian
+    float kernel[9] = {1./16., 2./16., 1./16., 2./16., 4./16., 2./16., 1./16., 2./16., 1./16.}; // gaussian
     // technically, sobel takes G = (G_x^2 + G_y^2)^.5 as an approximation of
     // the gradient, but stars are round, so any stars (or indeed other
     // features) will be sharp in x,y, or any other direction.
-    // int16_t kernel[9] = {-1, 0, 1, -2, 0, 2, -1, 0, 1}; // sobel x
+    // float kernel[9] = {-1., 0., 1., -2., 0., 2., -1., 0., 1.}; // sobel x
     uint16_t kernelSize = 9;
 
     struct timespec tstart = {0,0};
@@ -69,7 +69,8 @@ int main(int argc, char* argv[]) {
         nCalls -= 1;
         clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tstart);
 
-        doConvolution(imageBuffer, fakeMean, imageWidth, imageNumPix, mask, kernel, kernelSize, imageResult);
+        doConvolution(imageBuffer, imageWidth, imageNumPix, mask, kernel,
+            kernelSize, imageResult);
 
         clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tconv);
 
@@ -81,14 +82,6 @@ int main(int argc, char* argv[]) {
         }
 
         clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tend);
-
-        // if using Gaussian kernel to blur, divide by kernel prefactor to
-        // preserve flux
-        if (kernel[4] == 4) {
-            for (uint32_t i = 0; i < imageNumPix; i++) {
-                imageResult[i] /= 16.0;
-            }
-        }
 
         printf("doConvolution took about %.7f seconds to do conv, %.7f seconds "
             "to calc sqSum %lf\n",

--- a/tests/test_fits.c
+++ b/tests/test_fits.c
@@ -56,7 +56,7 @@ struct fits_metadata_t default_metadata = {
 
 int main(int argc, int* argv)
 {
-    char fileName[13] = "test.fits.gz";
+    char fileName[13] = "test.fits";
     uint16_t imageMem[TEST_FITS_IMG_WIDTH * TEST_FITS_IMG_HEIGHT] = {0};
 
     imageMem[(TEST_FITS_IMG_WIDTH * TEST_FITS_IMG_HEIGHT + TEST_FITS_IMG_WIDTH) / 2] = 4095;

--- a/timer.h
+++ b/timer.h
@@ -1,0 +1,16 @@
+#ifndef _TIMER_H
+#define _TIMER_H
+
+#include <time.h>
+
+extern struct timespec tstart;
+extern struct timespec tend;
+extern double deltaT;
+
+#define START(tstart) (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tstart))
+#define STOP(tend) (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tend))
+#define DELTA(t1, t0) (((double)t1.tv_sec + 1.0e-9*t1.tv_nsec) - \
+    ((double)t0.tv_sec + 1.0e-9*t0.tv_nsec))
+#define DISPLAY_DELTA(str, deltaT) (printf("%s: dt = %lf\n", str, deltaT))
+
+#endif


### PR DESCRIPTION
* Number of blobs found not necessarily equal to number sent to astrometry, that may be limited by `MAX_BLOBS`
  * This is however the important number for tuning image params and threshold sigma for successful solves
* Will send number to FC and SC-GUI