### PR TITLE
log sensor temperature

### DIFF
--- a/camera.h
+++ b/camera.h
@@ -78,9 +78,11 @@ extern struct camera_params all_camera_params;
 
 int setCameraParams();
 void setSaveImage();
+int initMessageQueue(void);
+int pollMessageQueue(void);
+int closeMessageQueue(void);
 int loadCamera();
 int initCamera();
-// int doContrastDetectAutoFocus(struct camera_params* all_camera_params, struct tm* tm_info, char* output_buffer);
 int getNumberOfCameras(int* pNumCams);
 int setExposureTime(double exposureTimeMs);
 


### PR DESCRIPTION
Implement peak API message queue listener
https://en.ids-imaging.com/manuals/ids-peak/ids-peak-comfortsdk-documentation/2.16.0/en/group__messagequeue.html

Temps are reported to `stdout` when verbose:

`handleTemperatureMessage: DeviceTimestamp: 5282462240300, Temperature: 41.19 degC , 106.14 degF`

The FITS files now have sensor temperature in degC inside:

```
XTENSION= 'BINTABLE'           / binary table extension
BITPIX  =                    8 / 8-bit bytes
NAXIS   =                    2 / 2-dimensional binary table
NAXIS1  =                    8 / width of table in bytes
NAXIS2  =                 3032 / number of rows in table
PCOUNT  =               555502 / size of special data area
GCOUNT  =                    1 / one data group (required keyword)
TFIELDS =                    1 / number of fields in each row
TTYPE1  = 'COMPRESSED_DATA'    / label for field   1
TFORM1  = '1PB(1085)'          / data format of field: variable length array
ZIMAGE  =                    T / extension contains compressed image
ZTILE1  =                 5320 / size of tiles to be compressed
ZTILE2  =                    1 / size of tiles to be compressed
ZCMPTYPE= 'RICE_1  '           / compression algorithm
ZNAME1  = 'BLOCKSIZE'          / compression block size
ZVAL1   =                   32 / pixels per block
ZNAME2  = 'BYTEPIX '           / bytes per pixel (1, 2, 4, or 8)
ZVAL2   =                    2 / bytes per pixel (1, 2, 4, or 8)
EXTNAME = 'COMPRESSED_IMAGE'
ZSIMPLE =                    T / file does conform to FITS standard
ZBITPIX =                   16 / number of bits per data pixel
ZNAXIS  =                    2 / number of data axes
ZNAXIS1 =                 5320 / length of data axis 1
ZNAXIS2 =                 3032 / length of data axis 2
ZEXTEND =                    T / FITS dataset may contain extensions
COMMENT   FITS (Flexible Image Transport System) format is defined in 'Astronomy
COMMENT   and Astrophysics', volume 376, page 359; bibcode: 2001A&A...376..359H
BZERO   =                32768 / offset data range to that of unsigned short
BSCALE  =                    1 / default scaling factor
ORIGIN  = 'blastcam'           / program used to generate file
INSTRUME= 'TIMcam  '           / instrument name
TELESCOP= 'Sigma 85mm f/1.4 DG HSM ART' / lens name
OBSERVAT= 'TIM     '           / observatory name
OBSERVER= 'starcam '           / observer name
FILENAME= '/home/starcam/Desktop/TIMSC/img/saved_image_2025-09-02_20-48-47.fits'
DATE    = '2025-09-02_20-48-47' / time of file creation (UTC)
UTC-SEC =           1756846127 / time of observation start, whole seconds portio
UTC-USEC=               376370 / time of observation start, microseconds portion
FILTER  = 'B+W 091 (630nm)'    / filter name
CCDTEMP =              41.1875 / camera temp (C)
FOCUS   =                   -8 / focus position (encoder units)
FOCUSMIN=                -7461 / min reported focus position (encoder units)
FOCUSMAX=                  506 / max reported focus position (encoder units)
APERTURE=                   14 / aperture position (10x fstop)
EXPTIME =            0.1000048 / total exposure time (s)
BUNIT   = 'ADU     '           / physical unit of array values
FZALGOR = 'RICE_1  '           / fitsio compression algorithm
FZTILE  = 'ROW     '           / fitsio compression tile scheme
DETECTOR= 'iDS U3-31N0CP-M-GL Rev. 2.2' / sensor name
SENSORID=                    1 / sensor unique ID
BITDEPTH=                   12 / requested bit depth of camera
PIXSCAL1=                 6.63 / plate scale, axis 1 (arcsec/px)
PIXSCAL2=                 6.63 / plate scale, axis 2 (arcsec/px)
PIXSIZE1=                 2.74 / pixel pitch, axis 1 (micron)
PIXSIZE2=                 2.74 / pixel pitch, axis 2 (micron)
DARKCUR =                 1.38 / avg dark current (e-/px/s)
RDNOISE1=                 2.37 / read noise (e-)
CCDBIN1 =                    1 / x-axis binning factor
CCDBIN2 =                    1 / y-axis binning factor
PIXELCLK=                 261. / pixel clock (MHz)
FRAMERTE=             9.999767 / framerate (Hz)
GAINFACT=                   1. / iDS gain factor setting
TRIGDLAY=                   0. / trigger delay (ms)
BLOFFSET=                    0 / black level offset setting (arb units)
AUTOGAIN=                    F / automatic gain control on (1) off (0)
AUTOEXP =                    F / automatic exposure control on (1) off (0)
AUTOBLK =                    F / automatic black level control on (1) off (0)
CHECKSUM= 'EHAlFG6kEGAkEG5k'   / HDU checksum updated 2025-09-02T20:48:47
DATASUM = '4192577923'         / data unit checksum updated 2025-09-02T20:48:47
END
```